### PR TITLE
CIP8: Off-chain storage

### DIFF
--- a/CIPs/0008.md
+++ b/CIPs/0008.md
@@ -1,0 +1,73 @@
+# CIP 0008: Expand Metadata to general off-chain storage
+
+- Date: 2020-05-05
+- Author: @nambrot
+- Status: WIP
+
+## Overview
+
+In CIP3, the Celo protocol has started with a simple off-chain storage mechanism mainly focused on claims an account can make about their off-chain identity and communicate to other participants in the network. Over time, there have been additional use cases which have similar access patterns that prompted the creation of `Metadata` in the first place. I.e. data that does not require the expensive cost of "hard consensus", instead just needs to be authenticated by a single party.
+
+Examples include:
+- Transaction metadata such as comments or encrypted messaging in general
+- Profile information such as name or a profile picture
+- Unidirectional attestations like an audit or badges won in The Great Celo Stake Off
+- Signed statements/claims by a party for relase binaries/docker images/package hashes
+
+## Goals
+
+- Expand storage and indexing capabilities of this off-chain data
+- Encode the notion of decryption keys
+- Lightweight messaging system
+
+
+## Proposed Solution
+
+We propose to add another claim, called the `STORAGE` claim:
+```json
+{
+  "type": "STORAGE",
+  "timestamp": 1588886114907,
+  "address": "https://example.com/celo_storage"
+}
+```
+
+The address should be referred to as the root. The expectation here is that data can accessed via `root/${dataAddress}`. For private data, this should be encrypted to the recipient. Here are some common ways of modeling applications into this format:
+
+- For transaction metadata, the account can encrypt the metadata and put it in a file with the transaction hash as the metadata. Further CIPs could specify a standard for structured metadata.
+    - `dataAddress`: `transactionHash`
+    - file contents: Encrypted, structured transaction metadata (comments, or otherwise)
+- Data in relation to other accounts could be communicated to other accounts with:
+    - `dataAddress`: `otherAccountAddress`
+    - file contents: Structured data such as:
+        - `sessionKeys`: The session key(s) encrypted with dataEncryptionKey of `otherAccount` on `Accounts.sol`
+        - `attestations`: These could be signed data attestating things such an audit or badges
+- Profile information could be stored on this system with:
+    - `dataAddress`: `profileName` or `profilePicture`
+    - file contents: the data unencrypted, or encrypted to session keys available to the recipients
+- Releases:
+    - `dataAddress`: `hashOfRelease`
+    - file contents: The signature of the key on the hash of the release
+
+If no assocation between to the `dataAddress` should be leaked, the `dataAddress` itself could be encrypted. The recipient would then just have to decrypt all `dataAddress`s (which could be available in an index file).
+
+
+## Alternative Solutions
+
+I considered doing storing all data on IPFS, however the tooling around IPFS as well as IPNS does not seem user-friendly enough to make a substantial number of users use this directly (or centralize anyways)
+
+## Risks
+
+More reliance on off-chain data and misunderstanding such reliance could lead to inconsistency or poor usability. Ultimately this is traded off against cost of storing data on-chain or in centralized services.
+
+## Useful Links
+
+* [The original Metadata CIP](https://github.com/celo-org/CIPs/blob/master/CIPs/0003.md)
+* Links to related CIPs or other documents
+
+## Implementation
+
+* To follow.
+* Or a link to a PR.
+
+Add any implementation considerations here. For all proposals going through the governance process, this section should reference the code implementing the proposed change. It’s recommended to get community feedback before writing any code.

--- a/CIPs/0008.md
+++ b/CIPs/0008.md
@@ -57,7 +57,7 @@ All file contents should always be signed by an authorized signer of the account
 
 ## Alternative Solutions
 
-I considered doing storing all data on IPFS, however the tooling around IPFS as well as IPNS does not seem user-friendly enough to make a substantial number of users use this directly (or centralize anyways). A generic "HTTP-based file system" is proposed as it is the lowest common denominator. It can be served by a simple HTTP server, even popular VCS static page hosting or specialized service providers.
+I considered doing storing all data on IPFS, however the tooling around IPFS as well as IPNS does not seem user-friendly enough to make a substantial number of users use this directly (or centralize anyways). A generic "HTTP-based file system" is proposed as it is the lowest common denominator. It can be served by a simple HTTP server, even popular VCS static page hosting or specialized service providers. The lock-in effect is minimal since data can be easily migrated, and multiple copies could even be hosted with multiple roots. Thus availabillity concerns relative to on-chain storage can be mitigated relatively well.
 
 ## Risks
 

--- a/CIPs/0008.md
+++ b/CIPs/0008.md
@@ -54,7 +54,7 @@ If no assocation between to the `dataAddress` should be leaked, the `dataAddress
 
 ## Alternative Solutions
 
-I considered doing storing all data on IPFS, however the tooling around IPFS as well as IPNS does not seem user-friendly enough to make a substantial number of users use this directly (or centralize anyways)
+I considered doing storing all data on IPFS, however the tooling around IPFS as well as IPNS does not seem user-friendly enough to make a substantial number of users use this directly (or centralize anyways). A generic "HTTP-based file system" is proposed as it is the lowest common denominator. It can be served by a simple HTTP server, even popular VCS static page hosting or specialized service providers.
 
 ## Risks
 

--- a/CIPs/0008.md
+++ b/CIPs/0008.md
@@ -33,15 +33,15 @@ We propose to add another claim, called the `STORAGE` claim:
 }
 ```
 
-This http address should be referred to as the root. The expectation here is that data can accessed via `root/${dataPath}`. A root can specify a REGEX with the `filterdataPaths` key to indicate what kind of data it stores. An account can make multiple `STORAGE` claims, both to increase availability, as well as effectively sharding this off-chain data. This CIP does not specify what to do in case of conflicts.
+This http address should be referred to as the root. The expectation here is that data can accessed via `root/${dataPath}`. A root can specify a [glob schema](https://github.com/isaacs/minimatch) with the `filterdataPaths` key to indicate what kind of data it stores. An account can make multiple `STORAGE` claims, both to increase availability, as well as effectively sharding this off-chain data. This CIP does not specify what to do in case of conflicts.
 
 Here are some common ways of modeling applications into this format:
 
 - For transaction metadata, the account can encrypt the metadata and put it in a file with the transaction hash as the metadata. Further CIPs could specify a standard for thee structure of that metadata.
-    - `dataPath`: `/transactions/transactionHash`
+    - `dataPath`: `/transactions/${transactionHash}`
     - file contents: Encrypted, structured transaction metadata (comments, or otherwise)
 - Data in relation to other accounts could be communicated to other accounts with:
-    - `dataPath`: `/accounts/otherAccountAddress`
+    - `dataPath`: `/accounts/${otherAccountAddress}`
     - file contents: Structured data such as:
         - `sessionKeys`: The session key(s) encrypted with dataEncryptionKey of `otherAccount` on `Accounts.sol`
         - `attestations`: These could be signed data attestating things such an audit or badges. An attested account could also store the attestations from the attestor here, as a client can just verify the signature of the attestor.
@@ -49,12 +49,12 @@ Here are some common ways of modeling applications into this format:
     - `dataPath`: `/profile/name` or `/profile/picture`
     - file contents: the data unencrypted, or encrypted to session keys available to the recipients
 - Releases:
-    - `dataPath`: `/releases/hashOfRelease`
+    - `dataPath`: `/releases/${hashOfRelease}`
     - file contents: The signature of the key on the hash of the release
 
 If no assocation between to the `dataPath` should be leaked, the `dataPath` itself could be encrypted. The recipient would then just have to decrypt all `dataPath`s (which could be available in an index file).
 
-All file contents should always be signed by an authorized signer of the account to prevent tampering by the file hoster. Signatures should be available under `${dataPath}.signature`. It is worth noting that this is only protecting against an adversary like the file hoster trying to provide unauthenticated plaintext. It does not protect against the adversary withholding or returning outdated data. If the order, including the existence, of the data is critical, then the developer should consider falling back to on-chain data, as consensus on the current view of the data is required. A possible partial workaround is to add expiry to the schema.
+All file contents should always be signed by an authorized signer of the account to prevent tampering by the file hoster. Signatures should be available under `${dataPath}.signature`. It is worth noting that this is only protecting against an adversary like the file hoster trying to provide unauthenticated plaintext. It does not protect against the adversary withholding or returning outdated data. Additionally, this does not protect against the adversary swapping out files. If data is being used for authorization, developers should consider adding the datapath itself to the plaintext to be signed. If the order, including the existence, of the data is critical, then the developer should consider falling back to on-chain data, as consensus on the current view of the data is required. A possible partial workaround is to add expiry to the schema.
 
 ## Alternative Solutions
 

--- a/CIPs/0008.md
+++ b/CIPs/0008.md
@@ -52,6 +52,8 @@ Here are some common ways of modeling applications into this format:
     - `dataAddress`: `/releases/hashOfRelease`
     - file contents: The signature of the key on the hash of the release
 
+Application developers should consider using standards such as JSON-LD to not reinvent the wheel
+
 If no assocation between to the `dataAddress` should be leaked, the `dataAddress` itself could be encrypted. The recipient would then just have to decrypt all `dataAddress`s (which could be available in an index file).
 
 All file contents should always be signed by an authorized signer of the account to prevent tampering by the file hoster. Signatures should be available under `${dataAddress}.signature`. It is worth noting that this is only protecting against an adversary like the file hoster trying to provide unauthenticated plaintext. It does not protect against the adversary withholding or returning outdated data. If the order, including the existence, of the data is critical, then the developer should consider falling back to on-chain data, as consensus on the current view of the data is required. A possible partial workaround is to add expiry to the schema.

--- a/CIPs/0008.md
+++ b/CIPs/0008.md
@@ -12,7 +12,7 @@ Examples include:
 - Transaction metadata such as comments or encrypted messaging in general
 - Profile information such as name or a profile picture
 - Unidirectional attestations like an audit or badges won in The Great Celo Stake Off
-- Signed statements/claims by a party for relase binaries/docker images/package hashes
+- Signed statements/claims by a party for release binaries/docker images/package hashes
 
 ## Goals
 

--- a/CIPs/0008.md
+++ b/CIPs/0008.md
@@ -29,34 +29,32 @@ We propose to add another claim, called the `STORAGE` claim:
   "type": "STORAGE",
   "timestamp": 1588886114907,
   "address": "https://example.com/celo_storage",
-  "filterDataAddresses": ".*"
+  "filterdataPaths": ".*"
 }
 ```
 
-This http address should be referred to as the root. The expectation here is that data can accessed via `root/${dataAddress}`. A root can specify a REGEX with the `filterDataAddresses` key to indicate what kind of data it stores. An account can make multiple `STORAGE` claims, both to increase availability, as well as effectively sharding this off-chain data. This CIP does not specify what to do in case of conflicts.
+This http address should be referred to as the root. The expectation here is that data can accessed via `root/${dataPath}`. A root can specify a REGEX with the `filterdataPaths` key to indicate what kind of data it stores. An account can make multiple `STORAGE` claims, both to increase availability, as well as effectively sharding this off-chain data. This CIP does not specify what to do in case of conflicts.
 
 Here are some common ways of modeling applications into this format:
 
 - For transaction metadata, the account can encrypt the metadata and put it in a file with the transaction hash as the metadata. Further CIPs could specify a standard for thee structure of that metadata.
-    - `dataAddress`: `/transactions/transactionHash`
+    - `dataPath`: `/transactions/transactionHash`
     - file contents: Encrypted, structured transaction metadata (comments, or otherwise)
 - Data in relation to other accounts could be communicated to other accounts with:
-    - `dataAddress`: `/accounts/otherAccountAddress`
+    - `dataPath`: `/accounts/otherAccountAddress`
     - file contents: Structured data such as:
         - `sessionKeys`: The session key(s) encrypted with dataEncryptionKey of `otherAccount` on `Accounts.sol`
         - `attestations`: These could be signed data attestating things such an audit or badges. An attested account could also store the attestations from the attestor here, as a client can just verify the signature of the attestor.
 - Profile information could be stored on this system with:
-    - `dataAddress`: `/profile/name` or `/profile/picture`
+    - `dataPath`: `/profile/name` or `/profile/picture`
     - file contents: the data unencrypted, or encrypted to session keys available to the recipients
 - Releases:
-    - `dataAddress`: `/releases/hashOfRelease`
+    - `dataPath`: `/releases/hashOfRelease`
     - file contents: The signature of the key on the hash of the release
 
-Application developers should consider using standards such as JSON-LD to not reinvent the wheel
+If no assocation between to the `dataPath` should be leaked, the `dataPath` itself could be encrypted. The recipient would then just have to decrypt all `dataPath`s (which could be available in an index file).
 
-If no assocation between to the `dataAddress` should be leaked, the `dataAddress` itself could be encrypted. The recipient would then just have to decrypt all `dataAddress`s (which could be available in an index file).
-
-All file contents should always be signed by an authorized signer of the account to prevent tampering by the file hoster. Signatures should be available under `${dataAddress}.signature`. It is worth noting that this is only protecting against an adversary like the file hoster trying to provide unauthenticated plaintext. It does not protect against the adversary withholding or returning outdated data. If the order, including the existence, of the data is critical, then the developer should consider falling back to on-chain data, as consensus on the current view of the data is required. A possible partial workaround is to add expiry to the schema.
+All file contents should always be signed by an authorized signer of the account to prevent tampering by the file hoster. Signatures should be available under `${dataPath}.signature`. It is worth noting that this is only protecting against an adversary like the file hoster trying to provide unauthenticated plaintext. It does not protect against the adversary withholding or returning outdated data. If the order, including the existence, of the data is critical, then the developer should consider falling back to on-chain data, as consensus on the current view of the data is required. A possible partial workaround is to add expiry to the schema.
 
 ## Alternative Solutions
 

--- a/CIPs/0008.md
+++ b/CIPs/0008.md
@@ -28,32 +28,33 @@ We propose to add another claim, called the `STORAGE` claim:
 {
   "type": "STORAGE",
   "timestamp": 1588886114907,
-  "address": "https://example.com/celo_storage"
+  "address": "https://example.com/celo_storage",
+  "filterDataAddresses": ".*"
 }
 ```
 
-Alternatively, this could be set directly on the `Accounts` smart contract directly, causing off-chain storage to effectively replace the existing metadata functionality. This would have the benefit of not duplicating similar functionality.
+This http address should be referred to as the root. The expectation here is that data can accessed via `root/${dataAddress}`. A root can specify a REGEX with the `filterDataAddresses` key to indicate what kind of data it stores. An account can make multiple `STORAGE` claims, both to increase availability, as well as effectively sharding this off-chain data. This CIP does not specify what to do in case of conflicts.
 
-Either way, this http address should be referred to as the root. The expectation here is that data can accessed via `root/${dataAddress}`. For private data, this should be encrypted to the recipient. Here are some common ways of modeling applications into this format:
+Here are some common ways of modeling applications into this format:
 
 - For transaction metadata, the account can encrypt the metadata and put it in a file with the transaction hash as the metadata. Further CIPs could specify a standard for thee structure of that metadata.
-    - `dataAddress`: `transactionHash`
+    - `dataAddress`: `/transactions/transactionHash`
     - file contents: Encrypted, structured transaction metadata (comments, or otherwise)
 - Data in relation to other accounts could be communicated to other accounts with:
-    - `dataAddress`: `otherAccountAddress`
+    - `dataAddress`: `/accounts/otherAccountAddress`
     - file contents: Structured data such as:
         - `sessionKeys`: The session key(s) encrypted with dataEncryptionKey of `otherAccount` on `Accounts.sol`
         - `attestations`: These could be signed data attestating things such an audit or badges. An attested account could also store the attestations from the attestor here, as a client can just verify the signature of the attestor.
 - Profile information could be stored on this system with:
-    - `dataAddress`: `profileName` or `profilePicture`
+    - `dataAddress`: `/profile/name` or `/profile/picture`
     - file contents: the data unencrypted, or encrypted to session keys available to the recipients
 - Releases:
-    - `dataAddress`: `hashOfRelease`
+    - `dataAddress`: `/releases/hashOfRelease`
     - file contents: The signature of the key on the hash of the release
 
 If no assocation between to the `dataAddress` should be leaked, the `dataAddress` itself could be encrypted. The recipient would then just have to decrypt all `dataAddress`s (which could be available in an index file).
 
-All file contents should always be signed by an authorized signer of the account to prevent tampering by the file hoster.
+All file contents should always be signed by an authorized signer of the account to prevent tampering by the file hoster. Signatures should be available under `${dataAddress}.signature`. It is worth noting that this is only protecting against an adversary like the file hoster trying to provide unauthenticated plaintext. It does not protect against the adversary withholding or returning outdated data. If the order, including the existence, of the data is critical, then the developer should consider falling back to on-chain data, as consensus on the current view of the data is required. A possible partial workaround is to add expiry to the schema.
 
 ## Alternative Solutions
 

--- a/CIPs/0008.md
+++ b/CIPs/0008.md
@@ -51,6 +51,7 @@ The address should be referred to as the root. The expectation here is that data
 
 If no assocation between to the `dataAddress` should be leaked, the `dataAddress` itself could be encrypted. The recipient would then just have to decrypt all `dataAddress`s (which could be available in an index file).
 
+All file contents should always be signed by an authorized signer of the account to prevent tampering by the file hoster.
 
 ## Alternative Solutions
 

--- a/CIPs/0008.md
+++ b/CIPs/0008.md
@@ -32,16 +32,18 @@ We propose to add another claim, called the `STORAGE` claim:
 }
 ```
 
-The address should be referred to as the root. The expectation here is that data can accessed via `root/${dataAddress}`. For private data, this should be encrypted to the recipient. Here are some common ways of modeling applications into this format:
+Alternatively, this could be set directly on the `Accounts` smart contract directly, causing off-chain storage to effectively replace the existing metadata functionality. This would have the benefit of not duplicating similar functionality.
 
-- For transaction metadata, the account can encrypt the metadata and put it in a file with the transaction hash as the metadata. Further CIPs could specify a standard for structured metadata.
+Either way, this http address should be referred to as the root. The expectation here is that data can accessed via `root/${dataAddress}`. For private data, this should be encrypted to the recipient. Here are some common ways of modeling applications into this format:
+
+- For transaction metadata, the account can encrypt the metadata and put it in a file with the transaction hash as the metadata. Further CIPs could specify a standard for thee structure of that metadata.
     - `dataAddress`: `transactionHash`
     - file contents: Encrypted, structured transaction metadata (comments, or otherwise)
 - Data in relation to other accounts could be communicated to other accounts with:
     - `dataAddress`: `otherAccountAddress`
     - file contents: Structured data such as:
         - `sessionKeys`: The session key(s) encrypted with dataEncryptionKey of `otherAccount` on `Accounts.sol`
-        - `attestations`: These could be signed data attestating things such an audit or badges
+        - `attestations`: These could be signed data attestating things such an audit or badges. An attested account could also store the attestations from the attestor here, as a client can just verify the signature of the attestor.
 - Profile information could be stored on this system with:
     - `dataAddress`: `profileName` or `profilePicture`
     - file contents: the data unencrypted, or encrypted to session keys available to the recipients


### PR DESCRIPTION
In CIP3, the Celo protocol has started with a simple off-chain storage mechanism mainly focused on claims an account can make about their off-chain identity and communicate to other participants in the network. Over time, there have been additional use cases which have similar access patterns that prompted the creation of `Metadata` in the first place. I.e. data that does not require the expensive cost of "hard consensus", instead just needs to be authenticated by a single party.

Examples include:
- Transaction metadata such as comments or encrypted messaging in general
- Profile information such as name or a profile picture
- Unidirectional attestations like an audit or badges won in The Great Celo Stake Off
- Signed statements/claims by a party for relase binaries/docker images/package hashes

This CIP should be ready for initial comments now. It should be worth noting that this CIP only proposes the general storage mechanism. Specific applications should generally specify their own schema on top of this mechanism and considered out of scope for this CIP (except maybe a reference application/schema)

To Add:
- [x] multiple storage roots and namespaces 
- [x] separate out signatures from files
- [x] allow for expiry of files