### PR TITLE
CGP 0003: Proposal to refer to Celo native asset as "Celo"

### DIFF
--- a/CGPs/0003.md
+++ b/CGPs/0003.md
@@ -1,9 +1,9 @@
-# CGP [0004]: Rename Celo Gold to Celo Native Asset
+# CGP [0003]: Rename Celo Gold to Celo Native Asset
 
-- Date: 2020-06-03
+- Date: 2020-06-04
 - Author(s): @JamesCowling
 - Status: DRAFT
-- Governance Proposal ID #: 4
+- Governance Proposal ID #: 3
 - Date Executed: [if executed]
 
 ## Overview

--- a/CGPs/0003.md
+++ b/CGPs/0003.md
@@ -41,6 +41,9 @@ to Gold in the Celo codebase. This is deemed as acceptable given that this
 complexity is levied on developers who are familiar with the ecosystem and not
 the general public.
 
+Note that the [BIP-0044 ticker symbol for Celo](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)
+will need to be changed.
+
 ### Usage guidelines
 
 - While the name Celo should be capitalized as a proper noun when used outside

--- a/CGPs/0004.md
+++ b/CGPs/0004.md
@@ -64,8 +64,8 @@ This proposal itself involves no code changes or verification.
   `LockedGold` and `ReleaseGold` smart contracts. These will likely remain
   referred to as gold within the codebase.
 - The name change will introduce some thrash and require renaming on exchanges
-  but as of the time of proposal Celo Gold is currently only listed on one
-  exchange.
+  but the earlier this is proposed the fewer exchanges that will need to be
+  updated.
 
 ## Useful Links
 

--- a/CGPs/0004.md
+++ b/CGPs/0004.md
@@ -1,0 +1,67 @@
+# CGP [0004]: Rename Celo Gold to Celo
+
+- Date: 2020-06-03
+- Author(s): @JamesCowling
+- Status: DRAFT
+- Governance Proposal ID #: 4
+- Date Executed: [if executed]
+
+## Overview
+
+This proposal decrees that the name "Celo Gold" be discontinued and that the
+Celo native asset be referred to simply as "Celo".
+
+The name Celo Gold is confusing since it doesn't relate to the price of gold.
+There will likely be multiple Celo stablecoins with names like Celo Dollar, Celo
+Euro and Celo Peso one day and potentially even a Celo Gold stablecoin.
+
+Even despite the potential naming collision, the gold metaphor doesn't
+adequately represent the properties of the native Celo asset, which include
+staking and voting on governance.
+
+The name "Celo" casts a clear distinction between the native asset and the
+suite of stablecoins that will develop over time.
+
+It is important to establish appropriate naming now while it's early in the
+life of the ecosystem.
+
+## Proposed Changes
+
+This proposal does not dictate specific transactions or code changes since these
+will have to roll out over time. It instead establishes the new naming
+in principal and can be subsequently acted upon by Celo contributors. These
+changes will span the Celo documentation and marketing, as well as the Celo
+codebase where appropriate.
+
+Note that it will likely not be feasible to exhaustively remove all references
+to Gold in the Celo codebase. This is deemed as acceptable given that this
+complexity is levied on developers who are familiar with the ecosystem and not
+the general public.
+
+### Usage guidelines
+
+- The name Celo should be capitalized unless used in code or tooling
+  where lowercase names would ordinarily be used for proper nouns.
+- The native asset should be referred to as Celo in both singular and plural
+  form, e.g., "what's the price of Celo?" "I'm staking some Celo on your group."
+- The recommended abbreviation and ticker symbol for Celo will be CELO.
+
+## Verification
+
+This proposal itself involves no code changes or verification.
+
+## Risks
+
+- There is a risk of confusion between "Celo" referring to the
+  ecosystem and "Celo" referring to the native asset. We believe the
+  distinction will be sufficiently clear when used in context.
+- Some refactoring may be too difficult, especially attempting to rename the
+  `lockedgold` smart contract. These will likely remain referred to as gold
+  within the codebase.
+- The name change will introduce some thrash and require renaming on exchanges
+  but as of the time of proposal Celo Gold is currently only listed on one
+  exchange.
+
+## Useful Links
+
+- [Original blog post arguing for the name change](https://medium.com/@censusworks/why-we-should-rename-celo-gold-35b04d87e95a)

--- a/CGPs/0004.md
+++ b/CGPs/0004.md
@@ -1,4 +1,4 @@
-# CGP [0004]: Rename Celo Gold to Celo
+# CGP [0004]: Rename Celo Gold to Celo Native Asset
 
 - Date: 2020-06-03
 - Author(s): @JamesCowling
@@ -9,7 +9,9 @@
 ## Overview
 
 This proposal decrees that the name "Celo Gold" be discontinued and that the
-Celo native asset be referred to simply as "Celo".
+Celo native asset be officially referred to as simply the "Celo native asset".
+The shortened name Celo (CELO) will be used as ticker symbol and in casual
+parlance.
 
 The name Celo Gold is confusing since it doesn't relate to the price of gold.
 There will likely be multiple Celo stablecoins with names like Celo Dollar, Celo
@@ -40,9 +42,12 @@ the general public.
 
 ### Usage guidelines
 
-- The name Celo should be capitalized unless used in code or tooling
-  where lowercase names would ordinarily be used for proper nouns.
-- The native asset should be referred to as Celo in both singular and plural
+- While the name Celo should be capitalized as a proper noun when used outside
+  of code/tooling, it's acceptable to use a lowercase "native asset" in the
+  long-form name.
+- Alternative long-form names such as "Celo reserve token" or "Celo staking
+  asset" should be avoided.
+- The shortened form should be referred to as Celo in both singular and plural
   form, e.g., "what's the price of Celo?" "I'm staking some Celo on your group."
 - The recommended abbreviation and ticker symbol for Celo will be CELO.
 
@@ -52,12 +57,12 @@ This proposal itself involves no code changes or verification.
 
 ## Risks
 
-- There is a risk of confusion between "Celo" referring to the
-  ecosystem and "Celo" referring to the native asset. We believe the
-  distinction will be sufficiently clear when used in context.
+- There is a risk of confusion between the shortened form referring to both the
+  ecosystem and the native asset. In contexts where the distinction is
+  insufficiently clear the long-form name should be used.
 - Some refactoring may be too difficult, especially attempting to rename the
-  `lockedgold` smart contract. These will likely remain referred to as gold
-  within the codebase.
+  `LockedGold` and `ReleaseGold` smart contracts. These will likely remain
+  referred to as gold within the codebase.
 - The name change will introduce some thrash and require renaming on exchanges
   but as of the time of proposal Celo Gold is currently only listed on one
   exchange.

--- a/CGPs/0004.md
+++ b/CGPs/0004.md
@@ -13,9 +13,10 @@ Celo native asset be officially referred to as simply the "Celo native asset".
 The shortened name Celo (CELO) will be used as ticker symbol and in casual
 parlance.
 
-The name Celo Gold is confusing since it doesn't relate to the price of gold.
-There will likely be multiple Celo stablecoins with names like Celo Dollar, Celo
-Euro and Celo Peso one day and potentially even a Celo Gold stablecoin.
+The name Celo Gold could be confusing since it doesn't relate to the price of
+gold. There will likely be multiple Celo stablecoins with names like Celo
+Dollar, Celo Euro and Celo Peso one day and potentially even a Celo Gold
+stablecoin.
 
 Even despite the potential naming collision, the gold metaphor doesn't
 adequately represent the properties of the native Celo asset, which include
@@ -57,8 +58,8 @@ This proposal itself involves no code changes or verification.
 
 ## Risks
 
-- There is a risk of confusion between the shortened form referring to both the
-  ecosystem and the native asset. In contexts where the distinction is
+- There could be a risk of confusion between the shortened form referring to
+  both the ecosystem and the native asset. In contexts where the distinction is
   insufficiently clear the long-form name should be used.
 - Some refactoring may be too difficult, especially attempting to rename the
   `LockedGold` and `ReleaseGold` smart contracts. These will likely remain


### PR DESCRIPTION
This proposal primarily pertains to deprecating the use of "Celo Gold" as a term used outside the codebase. While there is a significant degree of support for this proposal so far, it's still an active topic of debate on #governance and twitter. Getting this PR up now to allow iteration.