### PR TITLE
[0020] Extensible precompile for hash functions

### DIFF
--- a/CIPs/0020.md
+++ b/CIPs/0020.md
@@ -1,0 +1,127 @@
+# CIP [0020]: Generic hash function support via extensible precompile
+
+- Date: 2020-09-4
+- Author: @prestwich (James Prestwich)
+- Status: WIP
+
+### Terminology
+
+The key words "MUST", "MUST NOT", "SHOULD", and "MAY" in this document are to be interpreted as described in 
+[RFC 2119](https://www.rfc-editor.org/rfc/rfc2119.html).
+
+## Overview
+
+As a descendant of the EVM, Celo supports only a handful of common hash 
+functions. This restricts the design-space of Celo protocols, and 
+
+## Goals
+
+- Provide support for common cryptographic hash functions
+- Expand options for on-chain verification of protocols not specifically 
+designed for EVM compatibility
+    - e.g. Verification of off-chain signatures using Blake2Xs, including Celo's 
+    own epoch commitments within a smart contract.
+    - e.g. Verification of remote Proof of Work from a wide variety of chains
+- Provide a clear route for acceptance and adoption of additional hash functions
+
+## Proposed Solution
+
+Introduce a new precompiled contract at address [TBD] that provides access to 
+a set of pre-determined hash functions. The input to this pre-compile consists 
+of a one-byte selector, a function-specific parameter block, and the preimage. 
+The output of this pre-compile is dependent on the selector, and may be fixed- 
+or variable-length. If the selector is unknown (not on the current 
+compatibility list), or the function-specific, the precompile MUST return an 
+error.
+
+### Proposing an extension
+
+To be eligible for inclusion, a proposed hash function meet the following 
+criteria:
+
+1. There MUST be a standardized specification for the function.
+1. There MUST be an existing high-quality implementation in Go.
+    1. The proposer SHOULD provide an implementation of the precompile 
+    extension.
+1. The function MUST be pure.
+    1. This is intended to disqualify `ethash` and other stateful functions.
+1. The function MUST NOT be memory intensive
+    1. This is intended to disqualify "memory-hard" hash functions and other 
+    potential DoS vectors
+    1. E.g. `scrypt`, `argon`
+1. The function SHOULD NOT be a combination of other hash functions
+    1. Prefer adding each component separately, and building the composition
+    as a Solidity function.
+    1. This is intended to disqualify common PoW-specific combinations.
+    1. E.g. `sha256d`, `X11`,
+
+Once these criteria are met the function must be proposed via a pull request. 
+The pull request SHOULD include a link to an existing implementation and 
+concrete use case for the new hash function. The pull request MUST be named 
+according to the following template: `[CIP-0020 Extension] DigestFunctionName`.
+
+The pull request MUST update this CIP with the following information:
+
+1. A new row in the table below
+    1. The status MUST be set to `Proposed`.
+    1. The selector MUST be marked `TODO`. Selectors will be assigned by the 
+    reviewer, not the proposer.
+1. If any function-specific parameters are required:
+    1. A link to full documentation in a new file in the `CIP-0020/` folder.
+1. If the ouput is not a fixed-length digest:
+    1. A link to full documentation in a new file in the `CIP-0020/` folder.
+
+
+The pull request MUST NOT:
+
+1. Modify any existing table row or text outside of the table.
+1. Conflict with the selector or name of any existing function.
+
+### Review of new hash functions
+
+Reviewers MAY ask the proposer for additional justification or to clarify 
+decisions made with respect to the input and output formats. Reviewers SHOULD 
+accept any proposal that meets all criteria and contains a well-tested 
+implementation.
+
+
+
+### Supported Digest Functions
+
+<!--
+Update using https://www.tablesgenerator.com/markdown_tables
+-->
+
+| Selector | Function Name | Extended Docs | Input Format  | Output Format | Link to specification                                            | Status   |
+|----------|---------------|---------------|---------------|---------------|------------------------------------------------------------------|----------|
+| 0x00     | SHA3-256      | n/a           | preimage only | 32 bytes      | [Link](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf) | Proposed |
+| 0x01     | SHA3-512      | n/a           | preimage only | 64 bytes      | [Link](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf) | Proposed |
+| 0x02     | Keccak-512    | n/a           | preimage only | 64 bytes      | [Link](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf) | Proposed |
+| 0x10     | Blake2Xs      | TODO          | TODO          | Variable      |                                                                  | Proposed |
+
+## Alternative Solutions
+
+I considered adding one precompile per hash function, with each function 
+having its own CIP. This would use a potentially large, fragmented, portion
+of the precompile address space. Subjecting a new hash function to the full CIP
+review process seems unnecessary, as the use cases are clear and the risk is 
+low.
+
+## Risks
+
+- This is a permanent departure from compatibility with the Ethereum EVM, and 
+its functionality ought to be wrapped in a Celo-specific contract to prevent 
+accidental use in an Ethereum-targeted contract.
+
+- Given that this is a pure function exposed at the contract layer, it is 
+unlikely to have a significant risk on the consensus or governance processes.
+
+- Each hash function will need to be priced separately. The pricing function for
+this precompile will grow in complexity over time.
+
+- If more than 200 hash functions are merged, the selector space will become 
+crowded and we will need to plan to add a second selector byte.
+
+## Implementation
+
+* To follow.

--- a/CIPs/0020.md
+++ b/CIPs/0020.md
@@ -12,7 +12,15 @@ The key words "MUST", "MUST NOT", "SHOULD", and "MAY" in this document are to be
 ## Overview
 
 As a descendant of the EVM, Celo supports only a handful of common hash 
-functions. This restricts the design-space of Celo protocols, and 
+functions. This restricts the design-space of Celo protocols, and prevents
+certain protocols from being evaluated by the EVM. We propose a single 
+precompile that provides access to common cryptographic hashes, and can
+be easily extended with minimal impact on chain security and performance.
+
+We also propose a reduced subset of the CIP process that applies specifically
+to hash function enrollment. This CIP20 process is intended to reduce the 
+burden of review on CIP editors and Celo Blockchain developers, as well as
+speed inclusion of useful functionality for dapp developers. 
 
 ## Goals
 
@@ -76,6 +84,7 @@ The pull request MUST NOT:
 
 1. Modify any existing table row or text outside of the table.
 1. Conflict with the selector or name of any existing function.
+1. Modify any other files in this repository.
 
 ### Review of new hash functions
 
@@ -83,7 +92,6 @@ Reviewers MAY ask the proposer for additional justification or to clarify
 decisions made with respect to the input and output formats. Reviewers SHOULD 
 accept any proposal that meets all criteria and contains a well-tested 
 implementation.
-
 
 
 ### Supported Digest Functions

--- a/CIPs/0020.md
+++ b/CIPs/0020.md
@@ -4,7 +4,7 @@
 cip: 20
 title: Generic hash function support via extensible precompile
 author: James Prestwich <james@prestwi.ch>
-discussions-to: <URL>
+discussions-to: [link](https://forum.celo.org/t/cip20-extensible-hash-function-precompile/675)
 status: Draft
 type: Standards
 category: Ring 0
@@ -14,65 +14,65 @@ license: Apache 2.0
 
 ### Terminology
 
-The key words "MUST", "MUST NOT", "SHOULD", and "MAY" in this document are to be interpreted as described in 
+The key words "MUST", "MUST NOT", "SHOULD", and "MAY" in this document are to be interpreted as described in
 [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119.html).
 
 ## Simple Summary
 
 This CIP specifies an extensible precompile that provides access to multiple
-hash functions to the EVM. It also specifies a process for including new hash 
+hash functions to the EVM. It also specifies a process for including new hash
 functions in the precompile.
 
 ## Abstract
 
-As a descendant of the EVM, Celo supports only a handful of common hash 
+As a descendant of the EVM, Celo supports only a handful of common hash
 functions. This restricts the design-space of Celo protocols, and prevents
-certain protocols from being evaluated by the EVM. We propose a single 
+certain protocols from being evaluated by the EVM. We propose a single
 precompile that provides access to common cryptographic hashes, and can
 be easily extended with minimal impact on chain security and performance.
 
 We also propose a reduced subset of the CIP process that applies specifically
-to hash function enrollment. This CIP20 process is intended to reduce the 
+to hash function enrollment. This CIP20 process is intended to reduce the
 burden of review on CIP editors and Celo Blockchain developers, as well as
-speed inclusion of useful functionality for dapp developers. 
+speed inclusion of useful functionality for dapp developers.
 
 ## Motivation
 
 - Provide support for common cryptographic hash functions
-- Expand options for on-chain verification of protocols not specifically 
+- Expand options for on-chain verification of protocols not specifically
 designed for EVM compatibility
-    - e.g. Verification of off-chain signatures using Blake2Xs, including Celo's 
+    - e.g. Verification of off-chain signatures using Blake2Xs, including Celo's
     own epoch commitments within a smart contract.
     - e.g. Verification of remote Proof of Work from a wide variety of chains
 - Provide a clear route for acceptance and adoption of additional hash functions
 
 ## Specification
 
-Introduce a new precompiled contract at address [TBD] that provides access to 
-a set of pre-determined hash functions. The input to this pre-compile consists 
-of a one-byte selector, a function-specific parameter block, and the preimage. 
-The output of this pre-compile is dependent on the selector, and may be fixed- 
-or variable-length. If the selector is unknown (not on the current 
-compatibility list), or the function-specific, the precompile MUST return an 
+Introduce a new precompiled contract at address [TBD] that provides access to
+a set of pre-determined hash functions. The input to this pre-compile consists
+of a one-byte selector, a function-specific parameter block, and the preimage.
+The output of this pre-compile is dependent on the selector, and may be fixed-
+or variable-length. If the selector is unknown (not on the current
+compatibility list), or the function-specific, the precompile MUST return an
 error.
 
 ### Proposing an extension
 
-To be eligible for inclusion, a proposed hash function meet the following 
+To be eligible for inclusion, a proposed hash function meet the following
 criteria:
 
 1. There MUST be a standardized specification for the function.
 1. There MUST be an existing high-quality implementation in Go.
-    1. The proposer SHOULD provide an implementation of the precompile 
+    1. The proposer SHOULD provide an implementation of the precompile
     extension.
     1. The proposer SHOULD also provide test vectors, and fuzzing setups
     for this implementation.
-    1. The proposer SHOULD provide benchmarks according to the standardized 
+    1. The proposer SHOULD provide benchmarks according to the standardized
     CIP20 benchmarking process below.
 1. The function MUST be pure.
     1. This is intended to disqualify `ethash` and other stateful functions.
 1. The function MUST NOT be memory intensive
-    1. This is intended to disqualify "memory-hard" hash functions and other 
+    1. This is intended to disqualify "memory-hard" hash functions and other
     potential DoS vectors
     1. E.g. `scrypt`, `argon`
 1. The function SHOULD NOT be a combination of other hash functions
@@ -81,16 +81,16 @@ criteria:
     1. This is intended to disqualify common PoW-specific combinations.
     1. E.g. `sha256d`, `X11`,
 
-Once these criteria are met the function must be proposed via a pull request. 
-The pull request SHOULD include a link to an existing implementation and 
-concrete use case for the new hash function. The pull request MUST be named 
+Once these criteria are met the function must be proposed via a pull request.
+The pull request SHOULD include a link to an existing implementation and
+concrete use case for the new hash function. The pull request MUST be named
 according to the following template: `[CIP-0020 Extension] DigestFunctionName`.
 
 The pull request MUST update this CIP with the following information:
 
 1. A new row in the table below
     1. The status MUST be set to `Proposed`.
-    1. The selector MUST be marked `TODO`. Selectors will be assigned by the 
+    1. The selector MUST be marked `TODO`. Selectors will be assigned by the
     CIP editors, not the proposer.
 1. If any function-specific parameters are required:
     1. A link to full documentation in a new file in the `CIP-0020/` folder.
@@ -110,10 +110,10 @@ New hash functions will be reviewed by participants of the Celo ACD calls.
 Review will be scheduled via the ACD call process. Submitters are responsible
 for requesting that their submission be included in the agenda.
 
-Reviewers MAY ask the proposer for additional justification or to clarify 
+Reviewers MAY ask the proposer for additional justification or to clarify
 decisions made with respect to the input and output formats. Rough consensus of
-ACD call participants is required, but Reviewers SHOULD accept any proposal 
-that meets all criteria and contains a well-tested implementation. 
+ACD call participants is required, but Reviewers SHOULD accept any proposal
+that meets all criteria and contains a well-tested implementation.
 
 ### Supported Digest Functions
 
@@ -130,10 +130,10 @@ Update using https://www.tablesgenerator.com/markdown_tables
 | 0x11 | Blake2Xs      | CIP-0020/blake2s.md | configuration, key, and preimage | Variable      | [link](https://www.blake2.net/blake2x.pdf)                        | Proposed |
 ## Rationale
 
-I considered adding one precompile per hash function, with each function 
+I considered adding one precompile per hash function, with each function
 having its own CIP. This would use a potentially large, fragmented, portion
 of the precompile address space. Subjecting a new hash function to the full CIP
-review process seems unnecessary, as the use cases are clear and the risk is 
+review process seems unnecessary, as the use cases are clear and the risk is
 low.
 
 ## CIP-20 Benchmarking Process
@@ -150,17 +150,17 @@ low.
 
 ## Security Considerations
 
-- This is a permanent departure from compatibility with the Ethereum EVM, and 
-its functionality ought to be wrapped in a Celo-specific contract to prevent 
+- This is a permanent departure from compatibility with the Ethereum EVM, and
+its functionality ought to be wrapped in a Celo-specific contract to prevent
 accidental use in an Ethereum-targeted contract.
 
-- Given that this is a pure function exposed at the contract layer, it is 
+- Given that this is a pure function exposed at the contract layer, it is
 unlikely to have a significant risk on the consensus or governance processes.
 
 - Each hash function will need to be priced separately. The pricing function for
 this precompile will grow in complexity over time.
 
-- If more than 200 hash functions are merged, the selector space will become 
+- If more than 200 hash functions are merged, the selector space will become
 crowded and we will need to plan to add a second selector byte.
 
 ## License

--- a/CIPs/0020.md
+++ b/CIPs/0020.md
@@ -127,7 +127,7 @@ Update using https://www.tablesgenerator.com/markdown_tables
 | 0x01 | SHA3-512      | n/a                 | preimage only                    | 64 bytes      | [link](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf) | Proposed |
 | 0x02 | Keccak-512    | n/a                 | preimage only                    | 64 bytes      | [link](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf) | Proposed |
 | 0x10 | Blake2s       | CIP-0020/blake2s.md | configuration, key, and preimage | Variable      | [link](https://www.blake2.net/blake2.pdf)                        | Proposed |
-| 0x11 | Blake2Xs      | CIP-0020/blake2s.md | configuration, key, and preimage | Variable      | [link](https://www.blake2.net/blake2.pdf)                        | Proposed |
+| 0x11 | Blake2Xs      | CIP-0020/blake2s.md | configuration, key, and preimage | Variable      | [link](https://www.blake2.net/blake2x.pdf)                        | Proposed |
 ## Rationale
 
 I considered adding one precompile per hash function, with each function 

--- a/CIPs/0020.md
+++ b/CIPs/0020.md
@@ -65,6 +65,10 @@ criteria:
 1. There MUST be an existing high-quality implementation in Go.
     1. The proposer SHOULD provide an implementation of the precompile 
     extension.
+    1. The proposer SHOULD also provide test vectors, and fuzzing setups
+    for this implementation.
+    1. The proposer SHOULD provide benchmarks according to the standardized 
+    CIP20 benchmarking process below.
 1. The function MUST be pure.
     1. This is intended to disqualify `ethash` and other stateful functions.
 1. The function MUST NOT be memory intensive
@@ -87,7 +91,7 @@ The pull request MUST update this CIP with the following information:
 1. A new row in the table below
     1. The status MUST be set to `Proposed`.
     1. The selector MUST be marked `TODO`. Selectors will be assigned by the 
-    reviewer, not the proposer.
+    CIP editors, not the proposer.
 1. If any function-specific parameters are required:
     1. A link to full documentation in a new file in the `CIP-0020/` folder.
 1. If the ouput is not a fixed-length digest:
@@ -102,11 +106,14 @@ The pull request MUST NOT:
 
 ### Review of new hash functions
 
-Reviewers MAY ask the proposer for additional justification or to clarify 
-decisions made with respect to the input and output formats. Reviewers SHOULD 
-accept any proposal that meets all criteria and contains a well-tested 
-implementation.
+New hash functions will be reviewed by participants of the Celo ACD calls.
+Review will be scheduled via the ACD call process. Submitters are responsible
+for requesting that their submission be included in the agenda.
 
+Reviewers MAY ask the proposer for additional justification or to clarify 
+decisions made with respect to the input and output formats. Rough consensus of
+ACD call participants is required, but Reviewers SHOULD accept any proposal 
+that meets all criteria and contains a well-tested implementation. 
 
 ### Supported Digest Functions
 
@@ -128,6 +135,10 @@ having its own CIP. This would use a potentially large, fragmented, portion
 of the precompile address space. Subjecting a new hash function to the full CIP
 review process seems unnecessary, as the use cases are clear and the risk is 
 low.
+
+## CIP-20 Benchmarking Process
+
+`## TODO ##`
 
 ## Test Cases
 

--- a/CIPs/0020.md
+++ b/CIPs/0020.md
@@ -1,5 +1,3 @@
-# CIP [0020]: Generic hash function support via extensible precompile
-
 ---
 cip: 20
 title: Generic hash function support via extensible precompile

--- a/CIPs/0020.md
+++ b/CIPs/0020.md
@@ -1,15 +1,29 @@
 # CIP [0020]: Generic hash function support via extensible precompile
 
-- Date: 2020-09-4
-- Author: @prestwich (James Prestwich)
-- Status: WIP
+---
+cip: 20
+title: Generic hash function support via extensible precompile
+author: James Prestwich <james@prestwi.ch>
+discussions-to: <URL>
+status: Draft
+type: Standards
+category: Ring 0
+created: 2020-10-25
+license: Apache 2.0
+---
 
 ### Terminology
 
 The key words "MUST", "MUST NOT", "SHOULD", and "MAY" in this document are to be interpreted as described in 
 [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119.html).
 
-## Overview
+## Simple Summary
+
+This CIP specifies an extensible precompile that provides access to multiple
+hash functions to the EVM. It also specifies a process for including new hash 
+functions in the precompile.
+
+## Abstract
 
 As a descendant of the EVM, Celo supports only a handful of common hash 
 functions. This restricts the design-space of Celo protocols, and prevents
@@ -22,7 +36,7 @@ to hash function enrollment. This CIP20 process is intended to reduce the
 burden of review on CIP editors and Celo Blockchain developers, as well as
 speed inclusion of useful functionality for dapp developers. 
 
-## Goals
+## Motivation
 
 - Provide support for common cryptographic hash functions
 - Expand options for on-chain verification of protocols not specifically 
@@ -32,7 +46,7 @@ designed for EVM compatibility
     - e.g. Verification of remote Proof of Work from a wide variety of chains
 - Provide a clear route for acceptance and adoption of additional hash functions
 
-## Proposed Solution
+## Specification
 
 Introduce a new precompiled contract at address [TBD] that provides access to 
 a set of pre-determined hash functions. The input to this pre-compile consists 
@@ -107,7 +121,7 @@ Update using https://www.tablesgenerator.com/markdown_tables
 | 0x02     | Keccak-512    | n/a           | preimage only | 64 bytes      | [Link](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf) | Proposed |
 | 0x10     | Blake2Xs      | TODO          | TODO          | Variable      |                                                                  | Proposed |
 
-## Alternative Solutions
+## Rationale
 
 I considered adding one precompile per hash function, with each function 
 having its own CIP. This would use a potentially large, fragmented, portion
@@ -115,7 +129,15 @@ of the precompile address space. Subjecting a new hash function to the full CIP
 review process seems unnecessary, as the use cases are clear and the risk is 
 low.
 
-## Risks
+## Test Cases
+
+* To follow.
+
+## Implementation
+
+* To follow.
+
+## Security Considerations
 
 - This is a permanent departure from compatibility with the Ethereum EVM, and 
 its functionality ought to be wrapped in a Celo-specific contract to prevent 
@@ -130,6 +152,5 @@ this precompile will grow in complexity over time.
 - If more than 200 hash functions are merged, the selector space will become 
 crowded and we will need to plan to add a second selector byte.
 
-## Implementation
-
-* To follow.
+## License
+This work is licensed under the Apache License, Version 2.0.

--- a/CIPs/0020.md
+++ b/CIPs/0020.md
@@ -121,13 +121,13 @@ that meets all criteria and contains a well-tested implementation.
 Update using https://www.tablesgenerator.com/markdown_tables
 -->
 
-| Selector | Function Name | Extended Docs | Input Format  | Output Format | Link to specification                                            | Status   |
-|----------|---------------|---------------|---------------|---------------|------------------------------------------------------------------|----------|
-| 0x00     | SHA3-256      | n/a           | preimage only | 32 bytes      | [Link](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf) | Proposed |
-| 0x01     | SHA3-512      | n/a           | preimage only | 64 bytes      | [Link](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf) | Proposed |
-| 0x02     | Keccak-512    | n/a           | preimage only | 64 bytes      | [Link](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf) | Proposed |
-| 0x10     | Blake2Xs      | TODO          | TODO          | Variable      |                                                                  | Proposed |
-
+|      | Function Name | Extended Docs       | Input Format                     | Output Format | Link to specification                                            | Status   |
+|------|---------------|---------------------|----------------------------------|---------------|------------------------------------------------------------------|----------|
+| 0x00 | SHA3-256      | n/a                 | preimage only                    | 32 bytes      | [link](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf) | Proposed |
+| 0x01 | SHA3-512      | n/a                 | preimage only                    | 64 bytes      | [link](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf) | Proposed |
+| 0x02 | Keccak-512    | n/a                 | preimage only                    | 64 bytes      | [link](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf) | Proposed |
+| 0x10 | Blake2s       | CIP-0020/blake2s.md | configuration, key, and preimage | Variable      | [link](https://www.blake2.net/blake2.pdf)                        | Proposed |
+| 0x11 | Blake2Xs      | CIP-0020/blake2s.md | configuration, key, and preimage | Variable      | [link](https://www.blake2.net/blake2.pdf)                        | Proposed |
 ## Rationale
 
 I considered adding one precompile per hash function, with each function 

--- a/CIPs/CIP-0020/blake2s.md
+++ b/CIPs/CIP-0020/blake2s.md
@@ -63,11 +63,11 @@ of bytes actually queried). If `outputBytes` is set to `uint32(0)`, it will be
 interpreted as equal to xofLength.
 
 **Note**: We define `outputBytes` as a big-endian 16-bit number, encoded as
-exactly 4 bytes.
+exactly 2 bytes. This restricts the output to around 64 KiB.
 
 The input to the CIP20 interface for Blake2Xs is
 `configuration || key || outputBytes || preimage` where `||` is the
-concatenation operator. This creates a prefix of between 36 and 68 bytes
+concatenation operator. This creates a prefix of between 34 and 66 bytes
 (depending on the length of the key).
 
 Blake2Xs modifies the Blake2s config block above to specify the XOF digest
@@ -104,14 +104,14 @@ Compared to Blake2s, the `nodeOffset` block is shortened, and a new 16-bit
 
 **blake2xs**
 
-- `000120010100000000000000000000000000000000000000000000000000000000 000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f 00`
-    - 256 byte output - `0x0001`
-    - 14 byte key - `0x20`
-    - default tree options
-    - no salt or personalization
-    - key --
-    `000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f`
-    - preimage -- `00`
+- 20200101 00000000 00000000 1400 0000 0000000000000000 0000000000000000 000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f 0010 00
+	- Blake2s options:
+		- 32-byte key length
+		- XOF length set to 20 bytes (`0x1400`)
+    	- key -
+    `0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f`
+	- requesting the first 16 bytes - `0x0010`
+	- preimage -- `0x00`
 
 
 ## References

--- a/CIPs/CIP-0020/blake2s.md
+++ b/CIPs/CIP-0020/blake2s.md
@@ -117,6 +117,9 @@ Compared to Blake2s, the `nodeOffset` block is shortened, and a new 16-bit
 ## References
 
 - [Blake2 documentation](https://www.blake2.net/blake2.pdf)
+- [celo-blockchain integration](https://github.com/celo-org/celo-blockchain/tree/prestwich/cip-0020)
+
+Code snippets above are reproduced from the following blake2 libraries, which
+are dedicated to the public domain:
 - [Blake2s lib](https://github.com/dchest/blake2s)
 - [Blake2xs lib](https://github.com/dchest/blake2xs)
-- [celo-blockchain integration](https://github.com/celo-org/celo-blockchain/tree/prestwich/cip-0020)

--- a/CIPs/CIP-0020/blake2s.md
+++ b/CIPs/CIP-0020/blake2s.md
@@ -19,10 +19,34 @@ block. The input to the CIP20 interface to these functions is
 For clarity, within the configuration block, all multi-byte integers use 
 little-endian byte order.
 
-**blake2s** 
-
 The configuration block is specified in the blake2s documentation. It is
 exactly 32 bytes as follows:
+
+
+```
+type parameterBlock struct {
+	DigestSize      byte   // 0
+	KeyLength       byte   // 1
+	fanout          byte   // 2
+	depth           byte   // 3
+	leafLength      uint32 // 4-7
+	nodeOffset      uint48 // 8-13
+	nodeDepth       byte   // 14
+	innerLength     byte   // 15
+	Salt            []byte // 16-23
+	Personalization []byte // 24-31
+}
+```
+
+For example, the default configuration (blake2s-256) as specified in the Blake2 
+documentation is 
+`0x2000010100000000000000000000000000000000000000000000000000000000`. It 
+represents blake2s operating in sequential mode with no key, salt, or 
+personalization, outputting a `0x20` (32) byte digest.
+
+**blake2Xs**
+
+Blake2xs modifies the block above to specify the XOF digest length as follows:
 
 ```
 type parameterBlock struct {
@@ -40,32 +64,8 @@ type parameterBlock struct {
 }
 ```
 
-For example, the default configuration (blake2s-256) as specified in the Blake2 
-documentation is 
-`0x2000010100000000000000000000000000000000000000000000000000000000`. It 
-represents blake2s operating in sequential mode with no key, salt, or 
-personalization, outputting a `0x20` (32) byte digest.
-
-**blake2xs** 
-
-We modify the blake2s block slightly to allow longer digest sizes. Our blake2xs 
-configuration block is 33 bytes as follows:
-
-```
-type parameterBlock struct {
-	DigestSize      uint16 // 0
-	KeyLength       byte   // 1
-	fanout          byte   // 2
-	depth           byte   // 3
-	leafLength      uint32 // 4-7
-	nodeOffset      uint32 // 8-11
-	xofLength       uint16 // 12-13
-	nodeDepth       byte   // 14
-	innerLength     byte   // 15
-	Salt            []byte // 16-23
-	Personalization []byte // 24-31
-}
-```
+The nodeOffset block is shortened, and a new 16-bit `xofLength` field specifies 
+the desired output length of the XOF.
 
 ## Examples
 

--- a/CIPs/CIP-0020/blake2s.md
+++ b/CIPs/CIP-0020/blake2s.md
@@ -1,0 +1,93 @@
+## Blake2s
+
+## Simple Summary
+
+This document is a specification of the blake2s hash function and the blake2xs
+hash functions for CIP20.
+
+## Specification
+
+Blake2s allows several configuration options. To fully support these, the 
+precompile accepts a fixed-length configuration block in addition to the 
+preimage. To support keyed hashing, the configuration there is an optional, 
+variable-width key. The size of the key is specified within the configuration 
+block. The input to the CIP20 interface to these functions is 
+`configuration || key || preimage` where `||` is the concatenation operator.
+
+### Configuration Block
+
+For clarity, within the configuration block, all multi-byte integers use 
+little-endian byte order.
+
+**blake2s** 
+
+The configuration block is specified in the blake2s documentation. It is
+exactly 32 bytes as follows:
+
+```
+type parameterBlock struct {
+	DigestSize      byte   // 0
+	KeyLength       byte   // 1
+	fanout          byte   // 2
+	depth           byte   // 3
+	leafLength      uint32 // 4-7
+	nodeOffset      uint32 // 8-11
+	xofLength       uint16 // 12-13
+	nodeDepth       byte   // 14
+	innerLength     byte   // 15
+	Salt            []byte // 16-23
+	Personalization []byte // 24-31
+}
+```
+
+For example, the default configuration (blake2s-256) as specified in the Blake2 
+documentation is 
+`0x2000010100000000000000000000000000000000000000000000000000000000`. It 
+represents blake2s operating in sequential mode with no key, salt, or 
+personalization, outputting a `0x20` (32) byte digest.
+
+**blake2xs** 
+
+We modify the blake2s block slightly to allow longer digest sizes. Our blake2xs 
+configuration block is 33 bytes as follows:
+
+```
+type parameterBlock struct {
+	DigestSize      uint16 // 0
+	KeyLength       byte   // 1
+	fanout          byte   // 2
+	depth           byte   // 3
+	leafLength      uint32 // 4-7
+	nodeOffset      uint32 // 8-11
+	xofLength       uint16 // 12-13
+	nodeDepth       byte   // 14
+	innerLength     byte   // 15
+	Salt            []byte // 16-23
+	Personalization []byte // 24-31
+}
+```
+
+## Examples
+
+**blake2x**
+
+- TODO
+
+**blake2xs**
+
+- `000120010100000000000000000000000000000000000000000000000000000000 000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f 00`
+    - 256 byte output - `0x0001`
+    - 14 byte key - `0x20`
+    - default tree options
+    - no salt or personalization
+    - key -- 
+    `000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f`
+    - preimage -- `00`
+
+
+## References
+
+- [Blake2 documentation](https://www.blake2.net/blake2.pdf)
+- [Blake2s lib](https://github.com/dchest/blake2s)
+- [Blake2xs lib](https://github.com/dchest/blake2xs)
+- [celo-blockchain integration](https://github.com/celo-org/celo-blockchain/tree/prestwich/cip-0020)

--- a/CIPs/CIP-0020/blake2s.md
+++ b/CIPs/CIP-0020/blake2s.md
@@ -59,9 +59,10 @@ queries with an upper bound on total bytes queried. The upper bound is
 explicitly commited to within the hash function IV. To support this mode of
 operation without introducing state to the precompile, we allow the caller to
 specify both an `xofLength` (the upper bound) and an `outputBytes` (the number
-of bytes actually queried).
+of bytes actually queried). If `outputBytes` is set to `uint32(0)`, it will be
+interpreted as equal to xofLength.
 
-**Note**: We define `outputBytes` as a big-endian 32-bit number, encoded as
+**Note**: We define `outputBytes` as a big-endian 16-bit number, encoded as
 exactly 4 bytes.
 
 The input to the CIP20 interface for Blake2Xs is


### PR DESCRIPTION
A CIP for an extensible precompile for hash functions. Starts to specify the precompile itself, as well as a method for adding new hash functions. The intention is to provide a standardized process for upgrading the Celo EVM's cryptographic functionality with minimal developer overhead.

This CIP is currently a WIP. I would love feedback on the contract specification and review process. I have filled in a few common hash functions, as well as one extremely-targeted function (Blake2Xs).

TODOs:
- [x] Specification for Blake2Xs operation mode
- [ ] Benchmarks for gas consumption
- [x] (After review) An implementation of the precompile in go