### PR TITLE
CGP 11: Increase the block gas limit to 13M

### DIFF
--- a/CGPs/0011.md
+++ b/CGPs/0011.md
@@ -23,7 +23,25 @@ A side-effect of this proposal is the increase of transaction throughput by way 
 
 ## Testing
 
-TODO: Describe the testing that was done to ensure this is a safe change
+To check and validate the performance of the networks under high pressure of gas consumption, a celo testnet was deployed with the next parameters:
+
+- Running validators: 100
+- Elected validators: 100
+- Proxied validators: 75
+- Block time: 5 seconds
+- Epoch: Each 500 blocks
+- Celo-blockchain version: 1.0.1
+- Celo-monorepo (protocol) version: a049b200c7a7972463f2d088ec274d0fd1a4b32d
+- Validator resources: CPU = 4 cores; Memory = 10Gbi
+- Proxy resources: CPU = 4 cores; Memory = 10Gbi
+
+The load transactions were generated as token transfers, transfering different tokens and also using different currencies for paying the transaction fees.
+
+With a block gas limit of 17M and an equal constant load of 17M, the testnet was running for 6 hours and 45 minutes, with an average block time of 6.48 seconds. There were not any major stall of the network and the only issue observed was the duration of some epoch block, which took around 2-3 minutes.
+
+After reducing the block gas limit to 13M and the block gas consumption to keep it close to 13M, the testnet was running for 10 hours, without observing any major issue, being the average block time of 5.6 seconds and most of the epoch block duration around 2 minutes. We can explain the deviation from the 5 seconds block time due to the block duration for epoch and epoch+1 blocks.
+
+In the view of the results obtained after the testing, we can reach the conclusion that the network can handle an increament on the gas block limit to 13M without notoriously impacting the average block time.
 
 ## Verification
 

--- a/CGPs/0011.md
+++ b/CGPs/0011.md
@@ -23,7 +23,7 @@ A side-effect of this proposal is the increase of transaction throughput by way 
 
 ## Testing
 
-To check and validate the performance of the networks under high pressure of gas consumption, a celo testnet was deployed with the next parameters:
+To check and validate the performance of the networks under high pressure of gas consumption, a Celo testnet was deployed with the following parameters:
 
 - Running validators: 100
 - Elected validators: 100

--- a/CGPs/0011.md
+++ b/CGPs/0011.md
@@ -17,6 +17,10 @@ This proposal sets the gasLimit parameter of the Celoblockchain to 13M from 10M.
   - Data: A human readable description of the transaction data
   - Value: How much cGLD is being sent, and why?
 
+## Testing
+
+TODO: Describe the testing that was done to ensure this is a safe change
+
 ## Verification
 
 An explanation of how voters can verify that this CGP does what it intends to do. Can be left as “TODO” until the proposal is made. Include things like CLI commands to run and pointers to code.

--- a/CGPs/0011.md
+++ b/CGPs/0011.md
@@ -10,9 +10,9 @@
 
 This proposal sets the block gas limit parameter of the Celo blockchain to 13M from 10M. This change is necessary to accomodate the contract deploy of Celo core smart contracts in the upcoming first upgrade.
 
-At genesis, the block gas limit was actually 20M to accomodate the initial deploy as well. After the deploy of the Celo core smart contracts, the block gas limit was set down to a more conservative 10M. Since then, Javier Corteso (@jcortejoso) and Kevin Jue (@kevjue) have conducted some load-testing to determine whether raising the block gas limit is indeed safe (read more in the Testing section).
+At genesis, the block gas limit was actually 20M to accomodate the initial deploy as well. After the deploy of the Celo core smart contracts, the block gas limit was set down to a more conservative 10M to ensure that block space does not become a disruptive factor for consensus. Since then, Javier Corteso (@jcortejoso) and Kevin Jue (@kevjue) have conducted some load-testing to determine whether raising the block gas limit is indeed safe (read more in the Testing section).
 
-A side-effect of this proposal is the increase of transaction throughput by way of the increased block space by 30%.
+A side-effect of this proposal is the increase of transaction throughput by way of the increased block space by 30% since more computation and thus transactions can take place in a block.
 
 ## Proposed Changes
 

--- a/CGPs/0011.md
+++ b/CGPs/0011.md
@@ -1,0 +1,31 @@
+# CGP [0011]: Increase the gasLimit to 13M
+
+- Date: 2020-09-23
+- Author(s): @nambrot
+- Status: DRAFT
+- Governance Proposal ID #: [if submitted]
+- Date Executed: [if executed]
+
+## Overview
+
+This proposal sets the gasLimit parameter of the Celoblockchain to 13M from 10M. This change is necessary to accomodate the contract deploy of Celo core smart contracts whose size has increased since the initial deploy.
+
+## Proposed Changes
+
+1. Increase the gasLimit
+  - Destination: A human readable description of the address and method being called
+  - Data: A human readable description of the transaction data
+  - Value: How much cGLD is being sent, and why?
+
+## Verification
+
+An explanation of how voters can verify that this CGP does what it intends to do. Can be left as “TODO” until the proposal is made. Include things like CLI commands to run and pointers to code.
+
+## Risks
+
+Highlight any risks and concerns that may affect consensus, proof-of-stake, governance, protocol economics, the stability protocol, security, and privacy.
+
+## Useful Links
+
+* Optional section
+* Links to related CIPs or other documents (eg. if this is a proposal to point to a new instance of a smart contract that was updated)

--- a/CGPs/0011.md
+++ b/CGPs/0011.md
@@ -8,14 +8,18 @@
 
 ## Overview
 
-This proposal sets the gasLimit parameter of the Celoblockchain to 13M from 10M. This change is necessary to accomodate the contract deploy of Celo core smart contracts whose size has increased since the initial deploy.
+This proposal sets the block gas limit parameter of the Celo blockchain to 13M from 10M. This change is necessary to accomodate the contract deploy of Celo core smart contracts in the upcoming first upgrade.
+
+At genesis, the block gas limit was actually 20M to accomodate the initial deploy as well. After the deploy of the Celo core smart contracts, the block gas limit was set down to a more conservative 10M. Since then, Javier Corteso (@jcortejoso) and Kevin Jue (@kevjue) have conducted some load-testing to determine whether raising the block gas limit is indeed safe (read more in the Testing section).
+
+A side-effect of this proposal is the increase of transaction throughput by way of the increased block space by 30%.
 
 ## Proposed Changes
 
-1. Increase the gasLimit
-  - Destination: A human readable description of the address and method being called
-  - Data: A human readable description of the transaction data
-  - Value: How much cGLD is being sent, and why?
+1. Increase the block gas limit parameter
+  - Destination: Call `setBlockGasLimit` on the `BlockchainParameters` smart contract owned by `Governance`
+  - Data: 13 000 0000 (13 Million)
+  - Value: 0 (NA)
 
 ## Testing
 
@@ -23,13 +27,13 @@ TODO: Describe the testing that was done to ensure this is a safe change
 
 ## Verification
 
-An explanation of how voters can verify that this CGP does what it intends to do. Can be left as “TODO” until the proposal is made. Include things like CLI commands to run and pointers to code.
+TODO: Add confirmation commands once proposal is live
 
 ## Risks
 
-Highlight any risks and concerns that may affect consensus, proof-of-stake, governance, protocol economics, the stability protocol, security, and privacy.
+- While metrics in the testing environment indicated that consensus and block production remain within expected bounds, generally speaking, increases in block space mean higher computational needs which could impact consensus and block production under adversarial conditions that were not tested.
+- Increasing the block space could lead to a quicker growth of chain state which in the long run makes running full nodes more resource-intenstive and could affect decentralization adversely.
 
 ## Useful Links
 
-* Optional section
-* Links to related CIPs or other documents (eg. if this is a proposal to point to a new instance of a smart contract that was updated)
+* [Block gas limit entry in the genesis block](https://github.com/celo-org/celo-monorepo/blob/master/packages/celotool/genesis_rc1.json#L23)


### PR DESCRIPTION
# CGP [0011]: Increase the gasLimit to 13M

- Date: 2020-09-23
- Author(s): @nambrot
- Status: DRAFT
- Governance Proposal ID #: [if submitted]
- Date Executed: [if executed]

## Overview

This proposal sets the block gas limit parameter of the Celo blockchain to 13M from 10M. This change is necessary to accomodate the contract deploy of Celo core smart contracts in the upcoming first upgrade.

At genesis, the block gas limit was actually 20M to accomodate the initial deploy as well. After the deploy of the Celo core smart contracts, the block gas limit was set down to a more conservative 10M. Since then, Javier Corteso (@jcortejoso) and Kevin Jue (@kevjue) have conducted some load-testing to determine whether raising the block gas limit is indeed safe (read more in the Testing section).

A side-effect of this proposal is the increase of transaction throughput by way of the increased block space by 30%.

## Proposed Changes

1. Increase the block gas limit parameter
  - Destination: Call `setBlockGasLimit` on the `BlockchainParameters` smart contract owned by `Governance`
  - Data: 13 000 0000 (13 Million)
  - Value: 0 (NA)

## Testing

TODO: Describe the testing that was done to ensure this is a safe change

## Verification

TODO: Add confirmation commands once proposal is live

## Risks

- While metrics in the testing environment indicated that consensus and block production remain within expected bounds, generally speaking, increases in block space mean higher computational needs which could impact consensus and block production under adversarial conditions that were not tested.
- Increasing the block space could lead to a quicker growth of chain state which in the long run makes running full nodes more resource-intenstive and could affect decentralization adversely.

## Useful Links

* [Block gas limit entry in the genesis block](https://github.com/celo-org/celo-monorepo/blob/master/packages/celotool/genesis_rc1.json#L23)
