### PR TITLE
Reject CGP11

### DIFF
--- a/CGPs/0011.md
+++ b/CGPs/0011.md
@@ -2,7 +2,7 @@
 
 - Date: 2020-09-23
 - Author(s): @nambrot
-- Status: DRAFT
+- Status: REJECTED (typo in parameter)
 - Governance Proposal ID #: [if submitted]
 - Date Executed: [if executed]
 


### PR DESCRIPTION
CGP11 had a typo in the parameter. Instead of 13M, the proposal specified 130M as the new gas limit. Also see https://github.com/celo-org/celo-monorepo/issues/4812#issuecomment-708634850