### PR TITLE
CGP 12: Increase the block gas limit to 13M (Attempt #2)

### DIFF
--- a/CGPs/0012.md
+++ b/CGPs/0012.md
@@ -1,0 +1,59 @@
+# CGP [0012]: Increase the gasLimit to 13M (Attempt #2)
+
+- Date: 2020-10-14
+- Author(s): @nambrot
+- Status: DRAFT
+- Governance Proposal ID #: [if submitted]
+- Date Executed: [if executed]
+
+## Overview
+
+This proposal sets the block gas limit parameter of the Celo blockchain to 13M from 10M. This change is necessary to accomodate the contract deploy of Celo core smart contracts in the upcoming first upgrade.
+
+This proposal was originally already proposed in [CGP11](../0011.md) which contained a typo where it specified a new value of 130M instead of 13M. This proposal rectifies that mistake, thus the below content is mostly copied over.
+
+At genesis, the block gas limit was actually 20M to accomodate the initial deploy as well. After the deploy of the Celo core smart contracts, the block gas limit was set down to a more conservative 10M to ensure that block space does not become a disruptive factor for consensus. Since then, Javier Corteso (@jcortejoso) and Kevin Jue (@kevjue) have conducted some load-testing to determine whether raising the block gas limit is indeed safe (read more in the Testing section).
+
+A side-effect of this proposal is the increase of transaction throughput by way of the increased block space by 30% since more computation and thus transactions can take place in a block.
+
+## Proposed Changes
+
+1. Increase the block gas limit parameter
+  - Destination: Call `setBlockGasLimit` on the `BlockchainParameters` smart contract owned by `Governance`
+  - Data: 13 000 0000 (13 Million)
+  - Value: 0 (NA)
+
+## Testing
+
+To check and validate the performance of the networks under high pressure of gas consumption, a Celo testnet was deployed with the following parameters:
+
+- Running validators: 100
+- Elected validators: 100
+- Proxied validators: 75
+- Block time: 5 seconds
+- Epoch: Each 500 blocks
+- Celo-blockchain version: 1.0.1
+- Celo-monorepo (protocol) version: a049b200c7a7972463f2d088ec274d0fd1a4b32d
+- Validator resources: CPU = 4 cores; Memory = 10Gbi
+- Proxy resources: CPU = 4 cores; Memory = 10Gbi
+
+The load transactions were generated as token transfers, transfering different tokens and also using different currencies for paying the transaction fees.
+
+With a block gas limit of 17M and an equal constant load of 17M, the testnet was running for 6 hours and 45 minutes, with an average block time of 6.48 seconds. There were not any major stall of the network and the only issue observed was the duration of some epoch block, which took around 2-3 minutes.
+
+After reducing the block gas limit to 13M and the block gas consumption to keep it close to 13M, the testnet was running for 10 hours, without observing any major issue, being the average block time of 5.6 seconds and most of the epoch block duration around 2 minutes. We can explain the deviation from the 5 seconds block time due to the block duration for epoch and epoch+1 blocks.
+
+In the view of the results obtained after the testing, we can reach the conclusion that the network can handle an increament on the gas block limit to 13M without notoriously impacting the average block time.
+
+## Verification
+
+TODO: Add confirmation commands once proposal is live
+
+## Risks
+
+- While metrics in the testing environment indicated that consensus and block production remain within expected bounds, generally speaking, increases in block space mean higher computational needs which could impact consensus and block production under adversarial conditions that were not tested.
+- Increasing the block space could lead to a quicker growth of chain state which in the long run makes running full nodes more resource-intenstive and could affect decentralization adversely.
+
+## Useful Links
+
+* [Block gas limit entry in the genesis block](https://github.com/celo-org/celo-monorepo/blob/master/packages/celotool/genesis_rc1.json#L23)

--- a/CGPs/0012.md
+++ b/CGPs/0012.md
@@ -20,7 +20,7 @@ A side-effect of this proposal is the increase of transaction throughput by way 
 
 1. Increase the block gas limit parameter
   - Destination: Call `setBlockGasLimit` on the `BlockchainParameters` smart contract owned by `Governance`
-  - Data: 13 000 0000 (13 Million)
+  - Data: 13 000 000 (13 Million)
   - Value: 0 (NA)
 
 ## Testing


### PR DESCRIPTION
Old PR: https://github.com/celo-org/celo-proposals/pull/46

# CGP [0012]: Increase the gasLimit to 13M (Attempt 2)

- Date: 2020-10-14
- Author(s): @nambrot
- Status: DRAFT
- Governance Proposal ID #: [if submitted]
- Date Executed: [if executed]

## Overview

This proposal sets the block gas limit parameter of the Celo blockchain to 13M from 10M. This change is necessary to accomodate the contract deploy of Celo core smart contracts in the upcoming first upgrade.

This proposal was originally already proposed in [CGP11](../0011.md) which contained a typo where it specified a new value of 130M instead of 13M. This proposal rectifies that mistake, thus the below content is mostly copied over.

At genesis, the block gas limit was actually 20M to accomodate the initial deploy as well. After the deploy of the Celo core smart contracts, the block gas limit was set down to a more conservative 10M to ensure that block space does not become a disruptive factor for consensus. Since then, Javier Corteso (@jcortejoso) and Kevin Jue (@kevjue) have conducted some load-testing to determine whether raising the block gas limit is indeed safe (read more in the Testing section).

A side-effect of this proposal is the increase of transaction throughput by way of the increased block space by 30% since more computation and thus transactions can take place in a block.

## Proposed Changes

1. Increase the block gas limit parameter
  - Destination: Call `setBlockGasLimit` on the `BlockchainParameters` smart contract owned by `Governance`
  - Data: 13 000 000 (13 Million)
  - Value: 0 (NA)

## Testing

To check and validate the performance of the networks under high pressure of gas consumption, a Celo testnet was deployed with the following parameters:

- Running validators: 100
- Elected validators: 100
- Proxied validators: 75
- Block time: 5 seconds
- Epoch: Each 500 blocks
- Celo-blockchain version: 1.0.1
- Celo-monorepo (protocol) version: a049b200c7a7972463f2d088ec274d0fd1a4b32d
- Validator resources: CPU = 4 cores; Memory = 10Gbi
- Proxy resources: CPU = 4 cores; Memory = 10Gbi

The load transactions were generated as token transfers, transfering different tokens and also using different currencies for paying the transaction fees.

With a block gas limit of 17M and an equal constant load of 17M, the testnet was running for 6 hours and 45 minutes, with an average block time of 6.48 seconds. There were not any major stall of the network and the only issue observed was the duration of some epoch block, which took around 2-3 minutes.

After reducing the block gas limit to 13M and the block gas consumption to keep it close to 13M, the testnet was running for 10 hours, without observing any major issue, being the average block time of 5.6 seconds and most of the epoch block duration around 2 minutes. We can explain the deviation from the 5 seconds block time due to the block duration for epoch and epoch+1 blocks.

In the view of the results obtained after the testing, we can reach the conclusion that the network can handle an increament on the gas block limit to 13M without notoriously impacting the average block time.

## Verification

TODO: Add confirmation commands once proposal is live

## Risks

- While metrics in the testing environment indicated that consensus and block production remain within expected bounds, generally speaking, increases in block space mean higher computational needs which could impact consensus and block production under adversarial conditions that were not tested.
- Increasing the block space could lead to a quicker growth of chain state which in the long run makes running full nodes more resource-intenstive and could affect decentralization adversely.

## Useful Links

* [Block gas limit entry in the genesis block](https://github.com/celo-org/celo-monorepo/blob/master/packages/celotool/genesis_rc1.json#L23)
