### PR TITLE
[0022] Standard for Injected web3 Provider

### DIFF
--- a/CIPs/0022.md
+++ b/CIPs/0022.md
@@ -14,8 +14,8 @@
 ## Proposed Solution
 - Ready `ethereum.isMetaMask` property for MetaMask. Through this property, it can be seen that it is a provider injected in MetaMask.
 - So, it is suggested that providers injected in Celo have a property with the syntax of `celo[providerName]`.
-  * eg. Some injected provider has `celo.isExtWallet` property. It's injected by DSRV Celo Extension wallet
-  * eg. For DApp browser has `celo.isDexFair` too
+  * eg. Some injected provider has `celo.isDesktop` property. It's injected by DSRV Celo Extension wallet
+  * eg. For DApp browser has `celo.isMobile` too
 
 ## Useful Links
 - [MetaMask](https://docs.metamask.io/guide/ethereum-provider.html#properties)

--- a/CIPs/0022.md
+++ b/CIPs/0022.md
@@ -30,9 +30,9 @@ To increase usability and accessibility by allowing celo DApps to be used not on
 
 
 ## Implementation
-[Celo web signer](https://github.com/dexfair/celo-web-signer)
-[Celo remix plugin](https://github.com/dexfair/celo-remix-plugin)
-[DSRV Celo Extension Wallet](https://github.com/dsrvlabs/celo-extension-wallet)
+- [Celo web signer](https://github.com/dexfair/celo-web-signer)
+- [Celo remix plugin](https://github.com/dexfair/celo-remix-plugin)
+- [DSRV Celo Extension Wallet](https://github.com/dsrvlabs/celo-extension-wallet)
 
 ## Security Considerations
 

--- a/CIPs/0022.md
+++ b/CIPs/0022.md
@@ -1,21 +1,40 @@
-# CIP [0022]: Standard for Injacted web3 Provider
+---
+cip: 0022
+title: Standard for Injacted web3 Provider
+author: @daoauth @NAKsir-melody
+discussions-to:
+status: Draft
+type:
+category:
+created: 2020-10-29
+license: Apache 2.0
+---
 
-- Date: 2020-10-29
-- Author: @daoauth @NAKsir-melody
-- Status: DRAFT
+## Simple Summary
+Standard to find out the type of web3 provider to support dapps running in web browsers
 
-## Overview
-- Standard to find out the type of web3 provider to support dapps running in web browsers
-
-## Goals
+## Abstract
 - In the case of web DApps, you can only use [DSRV Celo Extension Wallet](https://chrome.google.com/webstore/detail/celo-desktop-wallet/kkilomkmpmkbdnfelcpgckmpcaemjcdh) or MetaMask Extension wallet, but a standard is required to distinguish them.
 - Through these standards, each provider can be identified and transactions can be sent to the Celo blockchain through appropriate operations.
 
-## Proposed Solution
-- Ready `ethereum.isMetaMask` property for MetaMask. Through this property, it can be seen that it is a provider injected in MetaMask.
+## Motivation
+To increase usability and accessibility by allowing celo DApps to be used not only in mobile environment but also in desktop environment.
+
+## Specification
+- Ready `ethereum.isMetaMask` property for MetaMask. Through this property, it can be seen that it is a provider injected in [MetaMask](https://docs.metamask.io/guide/ethereum-provider.html#properties).
 - So, it is suggested that providers injected in Celo have a property with the syntax of `celo[providerName]`.
   * eg. Some injected provider has `celo.isDesktop` property. It's injected by DSRV Celo Extension wallet
   * eg. For DApp browser has `celo.isMobile` too
 
-## Useful Links
-- [MetaMask](https://docs.metamask.io/guide/ethereum-provider.html#properties)
+## Test Cases
+
+
+## Implementation
+[Celo web signer](https://github.com/dexfair/celo-web-signer)
+[Celo remix plugin](https://github.com/dexfair/celo-remix-plugin)
+[DSRV Celo Extension Wallet](https://github.com/dsrvlabs/celo-extension-wallet)
+
+## Security Considerations
+
+## License
+This work is licensed under the Apache License, Version 2.0.

--- a/CIPs/0022.md
+++ b/CIPs/0022.md
@@ -1,6 +1,6 @@
 ---
 cip: 0022
-title: Standard for Injacted web3 Provider
+title: Standard for Injected web3 Provider
 author: @daoauth @NAKsir-melody
 discussions-to: https://github.com/celo-org/celo-proposals/issues/74
 status: Draft

--- a/CIPs/0022.md
+++ b/CIPs/0022.md
@@ -2,7 +2,7 @@
 cip: 0022
 title: Standard for Injacted web3 Provider
 author: @daoauth @NAKsir-melody
-discussions-to:
+discussions-to: https://github.com/celo-org/celo-proposals/issues/74
 status: Draft
 type:
 category:


### PR DESCRIPTION
## Overview
- Standard to find out the type of web3 provider to support dapps running in web browsers

## Goals
- In the case of web DApps, you can only use [DSRV Celo Extension Wallet](https://chrome.google.com/webstore/detail/celo-desktop-wallet/kkilomkmpmkbdnfelcpgckmpcaemjcdh) or MetaMask Extension wallet, but a standard is required to distinguish them.
- Through these standards, each provider can be identified and transactions can be sent to the Celo blockchain through appropriate operations.

## Proposed Solution
- Ready `ethereum.isMetaMask` property for MetaMask. Through this property, it can be seen that it is a provider injected in MetaMask.
- So, it is suggested that providers injected in Celo have a property with the syntax of `celo[providerName]`.
  * eg. Some injected provider has `celo.isDesktop` property. It's injected by DSRV Celo Extension wallet
  * eg. For DApp browser has `celo.isMobile` too

## Useful Links
- [MetaMask](https://docs.metamask.io/guide/ethereum-provider.html#properties)