### PR TITLE
Add CGP [0014]: cUSD Rewards

### DIFF
--- a/CGPs/0014.md
+++ b/CGPs/0014.md
@@ -1,0 +1,45 @@
+# CGP [0014]:  cUSD Rewards
+
+- Date: 2020-10-25
+- Author(s): @ewilz, @cla-bel, @nambrot, @timmoreton
+- Status: DRAFT
+- Governance Proposal ID #: [if submitted]
+- Date Executed: [if executed]
+
+## Overview
+
+**This CGP is currently a work in progress, exact numbers and figures are still being worked out based on community feedback. Figures surrounded by brackets [] are subject to change. As soon as the community agrees stewardship of the community fund, the authors would welcome input and direction from the stewards.**
+
+This proposal may be the first in a sequence of proposals that would deliver a reward in CELO based on cUSD holdings of eligible addresses for a limited period, anticipated over a course of [12] months. Rewards are proposed to come from the community fund and will be delivered on a [monthly] basis through a sequence of followup proposals. These proposals will determine monthly rewards based on the [time-weighted average] cUSD balance of each eligible address the preceding month. Assuming subsequent proposals are also passed, the sum of these monthly rewards would amount to an effective annualized rate of [6]%.
+ 
+This effort intends to reward early verified users of the Celo ecosystem and aims to disseminate rewards as widely as possible to individuals with modest balances accessing Celo through mobile devices. Addresses of users that have verified their phone number with at least 3 attestations will be eligible to receive these rewards on up to a maximum balance of [500] cUSD. Depending on uptake and community feedback, eligibility criteria may be reassessed at each subsequent proposal. No proposal would be made that would cause spending on this scheme to exceed [X] CELO, [Y]% of the community fund as of [date].
+
+Performing the distribution will happen in a few steps.
+1. Determine eligible addresses and rewards based on chain data from preceding month. Publish this as a merkle tree. The code and input data will be public so that the community can verify these details. 
+2. Deploy a merkle distributor contract containing the root of the published merkle tree.
+3. Via governance proposal, fund this specific merkle distributor contract with total rewards to be delivered this month.
+4. Transfer CELO to each eligible address using the merkle distributor contract. Depending on implementation details, clients may pull the rewards themselves, or an open-source script will allow anyone to make these transfers on behalf of others.
+
+
+## Proposed Changes
+
+1. Transfer `<total amount>` CELO to merkle distributor contract at `<address>`.
+  - Destination: GoldToken, transfer
+  - Data: `<address of merkle distributor contract>`, `<total rewards amount for month>`
+  - Value: 0
+
+
+## Verification
+
+The code and the input data used to generate the Merkle tree will be public so that the community can verify these details. 
+The smart contract code will be public and verifiable, and the implementation and Merkle root will be immutable. The proposal will identify the address of the contract, which voters can use to verify the total sum required and how it will be distributed.  
+
+
+## Risks
+
+A risk this proposal introduces includes a potential  loss of community funds if CELO is  transferred to inaccessible Celo addresses. 
+
+
+## Useful Links
+
+* Based on Uniswap's [merkle distributor code](https://github.com/Uniswap/merkle-distributor)


### PR DESCRIPTION
A CIP to deliver CELO rewards to holders of cUSD in order to incentivize engagement with valora and the celo platform. The exact details are still being worked out. Here is a list of key parameters as they currently stand:
- Reward: 6% annual
- Scheduled reward delivery: Monthly 
- Asset of payout: CELO 
- Max qualifying balance: 500 cUSD per verified address
- Qualifying criteria: has completed at least 3 attestations (automatic enrollment)
