### PR TITLE
Update CGP13 with no longer proxying linked libraries

### DIFF
--- a/CGPs/0013.md
+++ b/CGPs/0013.md
@@ -34,18 +34,14 @@ This Celo Core Contracts Upgrade proposal is special since it operationalizes th
 16. UsingPrecompilesProxy `setImplementation`
 17. ValidatorsProxy `setImplementation`
 
-Additionally, to avoid future updated bytecode of Celo Core Contracts when underlying libraries are changed, some libraries are being proxied and linked via the proxy. That necessitates the following transactions:
-
-1. Registry `setAddressFor` Signatures library
-2. Registry `setAddressFor` AddressLinkedList library
-3. Registry `setAddressFor` AddressSortedLinkedList library
-4. Registry `setAddressFor` AddressSortedLinkedListWithMedian library
-5. Registry `setAddressFor` Proposals library
-6. Registry `setAddressFor` IntegerSortedLinkedList library
-
 Regular features that were being added or bugs that were fixed are described in the [Github release](https://github.com/celo-org/celo-monorepo/releases/tag/celo-contracts-v1.rc1). Since the major version of these Celo Core Contracts changed due to the version change, no separate transactions will reflect the "regular" changes. One exception to that is the newly added `DowntimeSlasher`:
 
 1. Registry `setAddressFor` DowntimeSlasher
+2. DowntimeSlasherProxy `setAndInitializeImplementation`:
+    registryAddress: 0x000000000000000000000000000000000000ce10
+    _penalty: 100000000000000000000
+    _reward: 10000000000000000000
+    _slashableDowntime: 8640
 
 Since this release is larger than usual and includes a bit more complexity, it is crucial for Celo stakeholders to follow the verification steps below.
 


### PR DESCRIPTION
This PR updates CGP13 with the decision to no longer proxy linked libraries