### PR TITLE
[0022]: Upgrade epoch SNARK data for flexibility, slashability and security

### DIFF
--- a/CIPs/0021.md
+++ b/CIPs/0021.md
@@ -54,6 +54,7 @@ We define a few helper functions:
 * `BHHash` - Bowe-Hopwood hash, as specified in the [Zcash protocol specification](https://github.com/zcash/zips/blob/master/protocol/protocol.pdf), on the Edwards curve defined over the same base field as BLS12-377, as specified in the [Zexe paper](https://eprint.iacr.org/2018/962.pdf).
 * `Blake2Xs` - the Blake2s-based variant of Blake2X, defined in the [Blake2X paper](https://blake2.net/blake2x.pdf).
 * `pad(array, n, padding_element)` - enlarge the array to size `n`, adding `padding_element` in the new places.
+* `truncate(array, n)` - truncate the array to the first `n` elements.
 
 The encoding is currently implemented as:
 
@@ -69,22 +70,22 @@ Blake2Xs(
 
 where `validator_set` is the concatenation of the results of `encode_public_key_le` on each validator public key.
 
-We propose to change it to the following.
+We propose to change it to the following. We first define the parameters `MAX_VALIDATORS = 150` and `SEC_PARAM = 128`. We then specify the new encoding.
 
 ```
 Blake2Xs(
     encode_integer_16_le(epoch number) || 
     BHHash(
-        bytes_le_to_bits_le(parent_hash) ||
+        bytes_le_to_bits_le(truncate(parent_hash), SEC_PARAM/8) ||
         encode_integer_32_le(maximum_non_signers) || 
-        validator set
+        pad(validator set, MAX_VALIDATORS, G1_GENERATOR)
     )
 )
 ```
 
 where `validator_set` is the concatenation of the results of `encode_public_key_le` on each validator public key, `parent_hash` is the hash of the parent block header and
 
-`g1_generator = (81937999373150964239938255573465948239988671502647976594219695644855304257327692006745978603320413799295628339695, 241266749859715473739788878240585681733927191168601896383759122102112907357779751001206799952863815012735208165030)`
+`G1_GENERATOR = (81937999373150964239938255573465948239988671502647976594219695644855304257327692006745978603320413799295628339695, 241266749859715473739788878240585681733927191168601896383759122102112907357779751001206799952863815012735208165030)`
 
 
 ## Rationale
@@ -93,7 +94,7 @@ A single Plumo proof can support a fixed amount of validators and epochs. We bel
 
 Moving the epoch number outside the `BHHash` allows for an efficient on-chain double-signing proof - this proof doesn't need the information inside the `BHHash`, it's just required to show there are two aggregate signatures by a super majority on the same epoch number and distinct opaque outputs of `BHHash`.
 
-Adding the parent block header prevents the "future subcommittee" attack since it adds an unpredictable value that the attacker can't predict in advance and therefore can't pre-sign. Specifically, the header contains the state hash, which in turn contains the result of the Celo randomness beacon.
+Adding the parent block header prevents the "future subcommittee" attack since it adds an unpredictable value that the attacker can't predict in advance and therefore can't pre-sign. Specifically, the header contains the state hash, which in turn contains the result of the Celo randomness beacon. We take only `SEC_PARAM/8` bytes, since, assuming the bytes are sufficiently unpredictable, an attacker would need to pre-sign around `2^128` different messages in order to succeed.
 
 ## Test Cases
 
@@ -106,7 +107,7 @@ Adding the parent block header prevents the "future subcommittee" attack since i
 
 ## Deployment Considerations
 
-* This CIP can in fact deployed as a soft-fork, in the sense that only validators MUST upgrade. Full nodes and light-clients do not verify the correctness of this field. Nevertheless, we suggest to deploy it in a hard-fork to minimize the amount of upgrades validators have to perform.
+* This CIP can in fact be deployed as a soft-fork, in the sense that only validators MUST upgrade. Full nodes and light-clients do not verify the correctness of this field. Nevertheless, we suggest to deploy it in a hard-fork to minimize the amount of upgrades validators have to perform.
 
 * The CIP puts hard upper-bound on the number of validators to be 150.
 

--- a/CIPs/0021.md
+++ b/CIPs/0021.md
@@ -1,0 +1,118 @@
+# CIP [0022]: Upgrade epoch SNARK data for flexibility, slashability and security
+
+---
+cip: 22
+title: Upgrade epoch SNARK data for flexibility, slashability and security
+author: Kobi Gurkan <me@kobi.one>
+discussions-to: <URL>
+status: Draft
+type: Standards
+category: Ring 0
+created: 2020-10-30
+license: Apache 2.0
+---
+
+### Terminology
+
+The key words "MUST", "MUST NOT", "SHOULD", and "MAY" in this document are to be interpreted as described in 
+[RFC 2119](https://www.rfc-editor.org/rfc/rfc2119.html).
+
+We mention little-endian and big-endian both in the context of bytes and bits. In both contexts we mean for little-endian that it's encoded from the least-significant element to the most-significant one, and similarly for big-endian.
+
+The symbol `||` means array concatenation.
+
+## Simple Summary
+
+This CIP upgrade the epoch SNARK data structure, which is signed by validators during consensus:
+1. To be correct when there are less than a specified maximum amount of validators elected.
+2. To be slashable with reasonable costs on-chain.
+
+## Abstract
+
+Celo supports the Plumo ultra-light client protocol, where, instead of downloading and verifying many block headers, light clients can download SNARK proofs that updates their known validator set to a more recent one. This is facilitated by an "epoch SNARK data" structure which is a SNARK-friendly encoding of validator election results. This structure is signed by validators during consensus and a resulting aggregated BLS signature is stored in blocks following elections.
+
+The currently deployed version of the encoding can be improved:
+1. It only works correctly when the validator set is at its maximum size. 
+2. As it's designed to be SNARK-friendly, the encoding uses the Bowe-Hopwood SNARK-friendly hash function on the entire elected validator set. As a result, showing a double-signing proof currently requires hashing the entire elected validator set with a non EVM-friendly hash, having too high gas costs.
+3. It's vulnerable to a "future subcommittee" attack, where an attacker that compromises enough validators can pre-sign encodings with future epoch numbers and use them when their compromised subcommittee is elected in the future.
+
+This CIP upgrades the encoding to address all three topics.
+
+## Motivation
+
+- Support validator sets which are not full up to a specified maximum.
+- Create the necesasry infrastructure for on-chain slashing in the case of double-signing.
+
+## Specification
+
+We define a few helper functions:
+* `encode_integer_X_le` - encodes an unsigned_integer having X bits to bits in a little-endian order.
+* `encode_public_key_le` - encodes a BLS12-377 point to a compressed form in bits - the little-endian bits of the x coordinate and a single bit whether y is the greatest of the two possibilities.
+* `bits_be_to_bytes_le` - converts big-endian bits to little-endian bytes.
+* `bytes_le_to_bits_be` - converts little-endian bytes to big-endian bits.
+* `bytes_le_to_bits_le` - converts little-endian bytes to little-endian bits.
+* `BHHash` - Bowe-Hopwood hash, as specified in the [Zcash protocol specification](https://github.com/zcash/zips/blob/master/protocol/protocol.pdf), on the Edwards curve defined over the same base field as BLS12-377, as specified in the [Zexe paper](https://eprint.iacr.org/2018/962.pdf).
+* `Blake2Xs` - the Blake2s-based variant of Blake2X, defined in the [Blake2X paper](https://blake2.net/blake2x.pdf).
+* `pad(array, n, padding_element)` - enlarge the array to size `n`, adding `padding_element` in the new places.
+
+The encoding is currently implemented as:
+
+```
+Blake2Xs(
+    BHHash(
+        encode_integer_16_le(epoch number) || 
+        encode_integer_32_le(maximum_non_signers) || 
+        validator set
+    )
+)
+```
+
+where `validator_set` is the concatenation of the results of `encode_public_key_le` on each validator public key.
+
+We propose to change it to the following.
+
+```
+Blake2Xs(
+    encode_integer_16_le(epoch number) || 
+    BHHash(
+        bytes_le_to_bits_le(parent_hash) ||
+        encode_integer_32_le(maximum_non_signers) || 
+        validator set
+    )
+)
+```
+
+where `validator_set` is the concatenation of the results of `encode_public_key_le` on each validator public key, `parent_hash` is the hash of the parent block header and
+
+`g1_generator = (81937999373150964239938255573465948239988671502647976594219695644855304257327692006745978603320413799295628339695, 241266749859715473739788878240585681733927191168601896383759122102112907357779751001206799952863815012735208165030)`
+
+
+## Rationale
+
+A single Plumo proof can support a fixed amount of validators and epochs. We believe that 150 validators and 130 epochs (~= 130 days) will satisfy Celo's needs for the next 2 years.
+
+Moving the epoch number outside the `BHHash` allows for an efficient on-chain double-signing proof - this proof doesn't need the information inside the `BHHash`, it's just required to show there are two aggregate signatures by a super majority on the same epoch number and distinct opaque outputs of `BHHash`.
+
+Adding the parent block header prevents the "future subcommittee" attack since it adds an unpredictable value that the attacker can't predict in advance and therefore can't pre-sign. Specifically, the header contains the state hash, which in turn contains the result of the Celo randomness beacon.
+
+## Test Cases
+
+* **WIP** - We provide the [plumo-prover](https://github.com/celo-org/plumo-prover) codebase, which consumes data from a Celo deployment and generates Plumo proofs. It will be run on private testnets before the test period and on Alfajores and Baklava during the test period.
+* **WIP** - We provide a proof-of-concept implementation of a slashing contract that utilizes [CIP20](https://github.com/celo-org/celo-proposals/compare/prestwich/cip-0020) for Blake2Xs and [CIPX]() for BLS12-377 operations.
+
+## Implementation
+
+* **WIP** - The changes are implemented as PRs on [celo-blockhain](https://github.com/celo-org/celo-blockchain) ([#1158](https://github.com/celo-org/celo-blockchain/pull/1158)), [celo-bls-snark-rs](https://github.com/celo-org/celo-bls-snark-rs) ([#183](https://github.com/celo-org/celo-bls-snark-rs/pull/183)) and [celo-bls-go](https://github.com/celo-org/celo-bls-go).
+
+## Deployment Considerations
+
+* This CIP can in fact deployed as a soft-fork, in the sense that only validators MUST upgrade. Full nodes and light-clients do not verify the correctness of this field. Nevertheless, we suggest to deploy it in a hard-fork to minimize the amount of upgrades validators have to perform.
+
+* The CIP puts hard upper-bound on the number of validators to be 150.
+
+## Security Considerations
+
+* This is a change to the operations occuring in the COMMIT phase of the consensus protocol. This means that a bug in the implementation can hurt the liveness of the chain. The risk is somewhat mitigated by the fact that the inputs to encoding methods are self-generated by each validator and so a malicious proposer can't inject arbitrary inputs. Additionally, the signing portions of the code are largely unchanged and have been audited and running in production since Celo launched its mainnet.
+
+## License
+This work is licensed under the Apache License, Version 2.0.


### PR DESCRIPTION
A CIP for "epoch SNARK data" changes that supports validator sets up to size 150, enables slashing and addresses the "future subcommitte" attack. It's still WIP and is worked on by @nategraf, @lucasege, @mstraka100, @mrsmkl and me. I'd love to receive comments and discuss any aspect of it.
