### PR TITLE
Remove blake2xs from cip20 specification

### DIFF
--- a/CIPs/0020.md
+++ b/CIPs/0020.md
@@ -125,7 +125,7 @@ Update using https://www.tablesgenerator.com/markdown_tables
 | 0x01 | SHA3-512      | n/a                 | preimage only                    | 64 bytes      | [link](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf) | Proposed |
 | 0x02 | Keccak-512    | n/a                 | preimage only                    | 64 bytes      | [link](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf) | Proposed |
 | 0x10 | Blake2s       | CIP-0020/blake2s.md | configuration, key, and preimage | Variable      | [link](https://www.blake2.net/blake2.pdf)                        | Proposed |
-| 0x11 | Blake2Xs      | CIP-0020/blake2s.md | configuration, key, and preimage | Variable      | [link](https://www.blake2.net/blake2x.pdf)                        | Proposed |
+
 ## Rationale
 
 I considered adding one precompile per hash function, with each function

--- a/CIPs/CIP-0020/blake2s.md
+++ b/CIPs/CIP-0020/blake2s.md
@@ -52,66 +52,13 @@ documentation is
 represents blake2s operating in sequential mode with no key, salt, or
 personalization, outputting a `0x20` (32) byte digest.
 
-### Blake2Xs
-
-Blake2Xs produces a variable-length digest. It is designed to allow successive
-queries with an upper bound on total bytes queried. The upper bound is
-explicitly commited to within the hash function IV. To support this mode of
-operation without introducing state to the precompile, we allow the caller to
-specify both an `xofLength` (the upper bound) and an `outputBytes` (the number
-of bytes actually queried). If `outputBytes` is set to `uint32(0)`, it will be
-interpreted as equal to xofLength.
-
-**Note**: We define `outputBytes` as a big-endian 16-bit number, encoded as
-exactly 2 bytes. This restricts the output to around 64 KiB.
-
-The input to the CIP20 interface for Blake2Xs is
-`configuration || key || outputBytes || preimage` where `||` is the
-concatenation operator. This creates a prefix of between 34 and 66 bytes
-(depending on the length of the key).
-
-Blake2Xs modifies the Blake2s config block above to specify the XOF digest
-length as follows:
-
-```
-type parameterBlock struct {
-	DigestSize      byte   // 0
-	KeyLength       byte   // 1
-	fanout          byte   // 2
-	depth           byte   // 3
-	leafLength      uint32 // 4-7
-	nodeOffset      uint32 // 8-11
-	xofLength       uint16 // 12-13
-	nodeDepth       byte   // 14
-	innerLength     byte   // 15
-	Salt            []byte // 16-23
-	Personalization []byte // 24-31
-}
-```
-
-Compared to Blake2s, the `nodeOffset` block is shortened, and a new 16-bit
-`xofLength` field specifies the desired output length of the XOF.
-
 ## Gas Accounting
 
 - TODO
 
 ## Examples
 
-**blake2x**
-
 - TODO
-
-**blake2xs**
-
-- 20200101 00000000 00000000 1400 0000 0000000000000000 0000000000000000 000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f 0010 00
-	- Blake2s options:
-		- 32-byte key length
-		- XOF length set to 20 bytes (`0x1400`)
-    	- key -
-    `0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f`
-	- requesting the first 16 bytes - `0x0010`
-	- preimage -- `0x00`
 
 
 ## References


### PR DESCRIPTION
This PR removes blake2Xs from the CIP20 spec. Reasoning: existing implementations are generally of low quality, and it can be instantiated from successive applications of blake2s.