### PR TITLE
[CIP-20] add gas specification to cip20

### DIFF
--- a/CIPs/0020.md
+++ b/CIPs/0020.md
@@ -46,13 +46,13 @@ designed for EVM compatibility
 
 ## Specification
 
-Introduce a new precompiled contract at address [TBD] that provides access to
-a set of pre-determined hash functions. The input to this pre-compile consists
-of a one-byte selector, a function-specific parameter block, and the preimage.
-The output of this pre-compile is dependent on the selector, and may be fixed-
-or variable-length. If the selector is unknown (not on the current
-compatibility list), or the function-specific, the precompile MUST return an
-error.
+As of `FORK_BLOCK_NUMBER` we introduce a new precompiled contract at address
+[TBD] that provides access to a set of pre-determined hash functions. The input
+to this pre-compile consists of a one-byte selector, a function-specific
+parameter block, and the preimage. The output of this pre-compile is dependent
+on the selector, and may be fixed- or variable-length. If the selector is
+unknown (not on the current compatibility list), or the function-specific, the
+precompile MUST return an error.
 
 ### Proposing an extension
 
@@ -95,7 +95,6 @@ The pull request MUST update this CIP with the following information:
 1. If the ouput is not a fixed-length digest:
     1. A link to full documentation in a new file in the `CIP-0020/` folder.
 
-
 The pull request MUST NOT:
 
 1. Modify any existing table row or text outside of the table.
@@ -126,6 +125,24 @@ Update using https://www.tablesgenerator.com/markdown_tables
 | 0x02 | Keccak-512    | n/a                 | preimage only                    | 64 bytes      | [link](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf) | Proposed |
 | 0x10 | Blake2s       | CIP-0020/blake2s.md | configuration, key, and preimage | Variable      | [link](https://www.blake2.net/blake2.pdf)                        | Proposed |
 
+### Gas Costs
+
+Calling the precompile with an undefined selector or otherwise invalid input
+will cost `INVALID_CIP20_INPUT_GAS` (initially set to `200`) gas and cause an
+error.
+
+New hash functions MUST include a gas cost function and MUST include benchmarks
+that justify that function. This function SHOULD account for setup costs and
+per-block processing of input.
+
+The initial SHA3 variants (SHA3-256, SHA3-512, and Keccak-512) will be priced
+identically to the existing Keccak-256 at `30 + 6 / word` for 64-byte words.
+
+```python
+def price_sha3_variant(input: bytes) -> int:
+    return 30 + (len(input) // 64) * 6
+```
+
 ## Rationale
 
 I considered adding one precompile per hash function, with each function
@@ -144,7 +161,7 @@ low.
 
 ## Implementation
 
-* To follow.
+* [Branch](https://github.com/prestwich/celo-blockchain/tree/prestwich/cip-0020)
 
 ## Security Considerations
 


### PR DESCRIPTION
Adds gas specification and implementation link to CIP20. Right now, I have the keccak variants priced as the keccak opcode (plus the implied `CALL` overhead for accessing a precompile)