### PR TITLE
doc: Add precompile addresses to the specification

### DIFF
--- a/CIPs/cip-0020.md
+++ b/CIPs/cip-0020.md
@@ -48,7 +48,7 @@ designed for EVM compatibility
 ## Specification
 
 As of `FORK_BLOCK_NUMBER` we introduce a new precompiled contract at address
-[TBD] that provides access to a set of pre-determined hash functions. The input
+`0xE2` that provides access to a set of pre-determined hash functions. The input
 to this pre-compile consists of a one-byte selector, a function-specific
 parameter block, and the preimage. The output of this pre-compile is dependent
 on the selector, and may be fixed- or variable-length. If the selector is

--- a/CIPs/cip-0025.md
+++ b/CIPs/cip-0025.md
@@ -55,7 +55,7 @@ The proposal adds a new precompiled function `ED25519VFY` with the following inp
 - any non-zero value indicates a signature verification failure
 
 ### Address
-The address of `ED25519VFY` is `TBC`.
+The address of `ED25519VFY` is `0xF3`.
 
 ### Gas costs
 Gas cost for `ED25519VFY` is calculated with the formula:

--- a/CIPs/cip-0026.md
+++ b/CIPs/cip-0026.md
@@ -26,7 +26,7 @@ Currently it's not possible to get the validator BLS public key used for consens
 
 ## Specification
 
-The number of precompile is 0x... The input is interpreted in the same way as precompile for getting the validator address: it is 64 bytes, first 32 bytes are an integer representing the index of validator to get, and the second 32 bytes are an integer representing the block to access. These input values have the same conditions as the precompile for getting validator address: index must be smaller than the number of validator for the given block, and block number must be smaller than current block number.
+The address of the precompile is `0xE1` The input is interpreted in the same way as precompile for getting the validator address: it is 64 bytes, first 32 bytes are an integer representing the index of validator to get, and the second 32 bytes are an integer representing the block to access. These input values have the same conditions as the precompile for getting validator address: index must be smaller than the number of validator for the given block, and block number must be smaller than current block number.
 
 Returns the BLS public key in uncompressed format as 192 byte string. In the case of Celo, the BLS public key is a point in the BLS12-377 elliptic curve defined over Fp2 (G2). A value of Fp2 is represented as two numbers smaller than the base field modulus. These numbers are encoded as 64 byte little endian strings (function `LE`). So if we have a point (a+bi,c+di), it is serialized as `LE(a) || LE(b) || LE(c) || LE(d)`.
 

--- a/CIPs/cip-0030.md
+++ b/CIPs/cip-0030.md
@@ -33,13 +33,13 @@ Multiexponentiation operation is included to efficiently aggregate public keys o
 
 |Precompile   |Address   |
 |---|---|
-|BLS12_377_G1ADD          | TBA  |
-|BLS12_377_G1MUL          | TBA  |
-|BLS12_377_G1MULTIEXP     | TBA  |
-|BLS12_377_G2ADD          | TBA  |
-|BLS12_377_G2MUL          | TBA  |
-|BLS12_377_G2MULTIEXP     | TBA  |
-|BLS12_377_PAIRING        | TBA  |
+|BLS12_377_G1ADD          | 0xE9  |
+|BLS12_377_G1MUL          | 0xE8  |
+|BLS12_377_G1MULTIEXP     | 0xE7  |
+|BLS12_377_G2ADD          | 0xE6  |
+|BLS12_377_G2MUL          | 0xE5  |
+|BLS12_377_G2MULTIEXP     | 0xE4  |
+|BLS12_377_PAIRING        | 0xE3  |
 
 ## Motivation
 Motivation of this precompile is to add a cryptographic primitive that allows to get 120+ bits of security for operations over pairing friendly curve compared to the existing BN254 precompile that only provides 80 bits of security. In addition it allows efficient one-time recursive proof aggregations, e.g. proofs about existence of BLS12-377 based signature.

--- a/CIPs/cip-0031.md
+++ b/CIPs/cip-0031.md
@@ -38,15 +38,15 @@ Multiexponentiation operation is included to efficiently aggregate public keys o
 
 |Precompile   |Address   |
 |---|---|
-|BLS12_G1ADD          | TBA  |
-|BLS12_G1MUL          | TBA  |
-|BLS12_G1MULTIEXP     | TBA  |
-|BLS12_G2ADD          | TBA  |
-|BLS12_G2MUL          | TBA  |
-|BLS12_G2MULTIEXP     | TBA  |
-|BLS12_PAIRING        | TBA  |
-|BLS12_MAP_FP_TO_G1   | TBA  |
-|BLS12_MAP_FP2_TO_G2  | TBA  |
+|BLS12_G1ADD          | 0xF2  |
+|BLS12_G1MUL          | 0xF1  |
+|BLS12_G1MULTIEXP     | 0xF0  |
+|BLS12_G2ADD          | 0xEF  |
+|BLS12_G2MUL          | 0xEE  |
+|BLS12_G2MULTIEXP     | 0xED  |
+|BLS12_PAIRING        | 0xEC  |
+|BLS12_MAP_FP_TO_G1   | 0xEB  |
+|BLS12_MAP_FP2_TO_G2  | 0xEA  |
 
 ## Motivation
 


### PR DESCRIPTION
The logic to the address assignment follows that we are starting off after: https://github.com/celo-org/celo-monorepo/blob/master/packages/protocol/contracts/common/UsingPrecompiles.sol#L18

So, next address is 0xFF-12 and so on. Therefore, I have assigned addresses to the spec in the order they appear in the [Donut Meta spec](https://github.com/celo-org/celo-proposals/blob/master/CIPs/cip-0027.md):

```
CIP-25: 0xff-12 => 0xf3

CIP 31:
|Precompile   |Address   |
|---|---|
|BLS12_G1ADD          | 0Xf2  |
|BLS12_G1MUL          | 0xf1  |
|BLS12_G1MULTIEXP     | 0xf0  |
|BLS12_G2ADD          | 0xef |
|BLS12_G2MUL          | 0xee  |
|BLS12_G2MULTIEXP     | 0xed  |
|BLS12_PAIRING        | 0xec |
|BLS12_MAP_FP_TO_G1   | 0xeb  |
|BLS12_MAP_FP2_TO_G2  | 0xea  |


CIP 30
Precompile   |Address   |
---|---|
BLS12_377_G1ADD          | 0xe9  |
BLS12_377_G1MUL          | 0xe8 |
BLS12_377_G1MULTIEXP     | 0xe7  |
BLS12_377_G2ADD          | 0xe6 |
BLS12_377_G2MUL          | 0xe5  |
BLS12_377_G2MULTIEXP     | 0xe4  |
BLS12_377_PAIRING        | 0xe3  |

CIP-20
0xe2

CIP-26
0xe1
```