### PR TITLE
CIP-21: Fix lookbackWindow boundary check logic

### DIFF
--- a/CIPs/cip-0021.md
+++ b/CIPs/cip-0021.md
@@ -62,7 +62,7 @@ Before `HARDFORK_BLOCK` The `BlockchainParameters.sol` contract is updated to ad
 
 Starting at `HARDFORK_BLOCK`, block creation and validation MUST read the lookback window from chain state by calling the `BlockchainParameters` contract, rather than reading chain paramaters. Reward calculations are unaffected.
 
-If the return value is outside the safe window, the node MUST clamp the return value to that range such that `MIN_SAFE_LOOKBACK_WINDOW <= window <= MAX_SAFE_LOOKBACK_WINDOW`. If the result is greater than the epoch size, the node MUST discard the result and use `epochSize - 2` instead. If the epoch size is 3 or less, the node MUST error, as it is in an invalid state.
+If the return value is outside the safe window, the node MUST clamp the return value to that range such that `MIN_SAFE_LOOKBACK_WINDOW <= window <= MAX_SAFE_LOOKBACK_WINDOW`. If the result is greater than the `epoch size - 2`, the node MUST discard the result and use `epochSize - 2` instead. If the epoch size is 3 or less, the node MUST error, as it is in an invalid state.
 
 If the `BlockchainParameters.sol` contract errors or returns 0, the node MUST use the default value `MIN_SAFE_LOOKBACK_WINDOW`.
 
@@ -84,10 +84,11 @@ def get_lookback_window(chain: ChainState) -> int:
     except EVMExecutionError:
         window = MIN_SAFE_LOOKBACK_WINDOW
 
+    # invalid chain param
+    assert chain.params.epoch_size > 3
+
     # ensure it is sensible given the chain params
-    if window > chain.params.epoch_size:
-        # invalid chain param
-        assert chain.params.epoch_size > 3
+    if window > chain.params.epoch_size - 2:
         window = chain.params.epoch_size - 2
 
     return window


### PR DESCRIPTION
Value `epoch` and `epoch - 1` are invalid for lookbackWindow; so the condition should check for value above `epoch -2`