### PR TITLE
cip-21: change MinSafeLookbackWindow

### DIFF
--- a/CIPs/cip-0021.md
+++ b/CIPs/cip-0021.md
@@ -43,7 +43,7 @@ The proposed solution is to migrate the parameter to the EVM state (layer 2).
 
 We define the following constants:
 
-- `MIN_SAFE_LOOKBACK_WINDOW = 12`
+- `MIN_SAFE_LOOKBACK_WINDOW = 3`
 - `MAX_SAFE_LOOKBACK_WINDOW = 720`
 
 Before `HARDFORK_BLOCK` The `BlockchainParameters.sol` contract is updated to add a new public state variable `uptimeLookbackWindow` with a governable setter.


### PR DESCRIPTION
Change minSafeLookbackWindow from 12 to 3 to accomodate to really small epochs (testnets)