### PR TITLE
spec: resolve word confusion in CIP20 hash function gas pricing

### DIFF
--- a/CIPs/CIP-0020/blake2s.md
+++ b/CIPs/CIP-0020/blake2s.md
@@ -57,36 +57,35 @@ personalization, outputting a `0x20` (32) byte digest.
 Gas for Blake2s will be set equal to SHA256 costs: `60 + (12 * words)`. The
 number of words is calculated without the configuration block (equivalent to
 the total length of the input minus the length of the configuration). If the
-input is less than 32 bytes, it is invalid, and the pricing function MUST
-return `INVALID_CIP20_INPUT_GAS`.
+input is less than the configuration size (32 bytes), it is invalid, and the
+pricing function MUST return `INVALID_CIP20_INPUT_GAS`.
 
 ```python
+EVM_WORD_SIZE: int = 32
+BLAKE2_CONFIG_SIZE: int = 32
+
 def price_word_metered_hash(
 	base: int,
 	per_word: int,
-	word_size: int,
 	input: bytes
 ) -> int:
-    length_ceiling = len(input) + word_size - 1
-    words = length_ceiling // word_size
+    length_ceiling = len(input) + EVM_WORD_SIZE - 1
+    words = length_ceiling // EVM_WORD_SIZE
     return base + words * per_word
 
 def price_blake2s(input: bytes) -> int:
-	if len(input) < 32:
+	if len(input) < BLAKE2_CONFIG_SIZE:
 		return INVALID_CIP20_INPUT_GAS
 	return price_word_metered_hash(
 		60,
 		12,
-		32,
-		input[32:]
+		input[BLAKE2_CONFIG_SIZE:]
 	)
 ```
-
 
 ## Examples
 
 - TODO
-
 
 ## References
 
@@ -95,5 +94,6 @@ def price_blake2s(input: bytes) -> int:
 
 Code snippets above are reproduced from the following blake2 libraries, which
 are dedicated to the public domain:
+
 - [Blake2s lib](https://github.com/dchest/blake2s)
 - [Blake2xs lib](https://github.com/dchest/blake2xs)

--- a/CIPs/cip-0020.md
+++ b/CIPs/cip-0020.md
@@ -39,10 +39,8 @@ speed inclusion of useful functionality for dapp developers.
 
 - Provide support for common cryptographic hash functions
 - Expand options for on-chain verification of protocols not specifically
-designed for EVM compatibility
-    - e.g. Verification of off-chain signatures using Blake2Xs, including Celo's
-    own epoch commitments within a smart contract.
-    - e.g. Verification of remote Proof of Work from a wide variety of chains
+  designed for EVM compatibility - e.g. Verification of off-chain signatures using Blake2Xs, including Celo's
+  own epoch commitments within a smart contract. - e.g. Verification of remote Proof of Work from a wide variety of chains
 - Provide a clear route for acceptance and adoption of additional hash functions
 
 ## Specification
@@ -62,23 +60,23 @@ criteria:
 
 1. There MUST be a standardized specification for the function.
 1. There MUST be an existing high-quality implementation in Go.
-    1. The proposer SHOULD provide an implementation of the precompile
-    extension.
-    1. The proposer SHOULD also provide test vectors, and fuzzing setups
-    for this implementation.
-    1. The proposer SHOULD provide benchmarks according to the standardized
-    CIP20 benchmarking process below.
+   1. The proposer SHOULD provide an implementation of the precompile
+      extension.
+   1. The proposer SHOULD also provide test vectors, and fuzzing setups
+      for this implementation.
+   1. The proposer SHOULD provide benchmarks according to the standardized
+      CIP20 benchmarking process below.
 1. The function MUST be pure.
-    1. This is intended to disqualify `ethash` and other stateful functions.
+   1. This is intended to disqualify `ethash` and other stateful functions.
 1. The function MUST NOT be memory intensive
-    1. This is intended to disqualify "memory-hard" hash functions and other
-    potential DoS vectors
-    1. E.g. `scrypt`, `argon`
+   1. This is intended to disqualify "memory-hard" hash functions and other
+      potential DoS vectors
+   1. E.g. `scrypt`, `argon`
 1. The function SHOULD NOT be a combination of other hash functions
-    1. Prefer adding each component separately, and building the composition
-    as a Solidity function.
-    1. This is intended to disqualify common PoW-specific combinations.
-    1. E.g. `sha256d`, `X11`,
+   1. Prefer adding each component separately, and building the composition
+      as a Solidity function.
+   1. This is intended to disqualify common PoW-specific combinations.
+   1. E.g. `sha256d`, `X11`,
 
 Once these criteria are met the function must be proposed via a pull request.
 The pull request SHOULD include a link to an existing implementation and
@@ -88,13 +86,13 @@ according to the following template: `[CIP-0020 Extension] DigestFunctionName`.
 The pull request MUST update this CIP with the following information:
 
 1. A new row in the table below
-    1. The status MUST be set to `Proposed`.
-    1. The selector MUST be marked `TODO`. Selectors will be assigned by the
-    CIP editors, not the proposer.
+   1. The status MUST be set to `Proposed`.
+   1. The selector MUST be marked `TODO`. Selectors will be assigned by the
+      CIP editors, not the proposer.
 1. If any function-specific parameters are required:
-    1. A link to full documentation in a new file in the `CIP-0020/` folder.
+   1. A link to full documentation in a new file in the `CIP-0020/` folder.
 1. If the ouput is not a fixed-length digest:
-    1. A link to full documentation in a new file in the `CIP-0020/` folder.
+   1. A link to full documentation in a new file in the `CIP-0020/` folder.
 
 The pull request MUST NOT:
 
@@ -120,7 +118,7 @@ Update using https://www.tablesgenerator.com/markdown_tables
 -->
 
 |      | Function Name | Extended Docs       | Input Format                     | Output Format | Link to specification                                            | Status   |
-|------|---------------|---------------------|----------------------------------|---------------|------------------------------------------------------------------|----------|
+| ---- | ------------- | ------------------- | -------------------------------- | ------------- | ---------------------------------------------------------------- | -------- |
 | 0x00 | SHA3-256      | n/a                 | preimage only                    | 32 bytes      | [link](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf) | Proposed |
 | 0x01 | SHA3-512      | n/a                 | preimage only                    | 64 bytes      | [link](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf) | Proposed |
 | 0x02 | Keccak-512    | n/a                 | preimage only                    | 64 bytes      | [link](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf) | Proposed |
@@ -135,33 +133,36 @@ error.
 
 New hash functions MUST include a gas cost function and MUST include benchmarks
 that justify that function. This function SHOULD account for setup costs and
-per-block processing of input.
+per-block processing of input. To conform to existing hash function precompile
+and opcode behavior, e recommend they be priced as a base gas cost for the
+invocation plus an amount of gas per EVM word processed.
 
 The initial SHA-3 variants (SHA3-256, SHA3-512, and Keccak-512) will be priced
-identically to the existing Keccak-256 at `30 + (6 * words)` for 64-byte words.
+identically to the existing Keccak-256 at `30 + (6 * words)`.
 
-The initial SHA-2 variant (SHA2-512) will be priced similarly to the existing
-SHA2-256 precompile. It will cost at `60 + (12 * words)` for 64-byte words.
-Note that while SHA2-256 uses 32-byte words, SHA2-512 uses 64-byte words.
-We choose to preserve the cost function in terms of words. While SHA2-512 is
-now cheaper to execute per-byte that SHA2-256, we do not anticipate DoS issues.
+The initial SHA-2 variant (SHA2-512) will be priced identically to the existing
+SHA2-256 precompile. It will cost `60 + (12 * words)`.
+
+Please refer to the blake2s document for details of the blake2s gas pricing
+function.
 
 ```python
+EVM_WORD_SIZE: int = 32
+
 def price_word_metered_hash(
 	base: int,
 	per_word: int,
-	word_size: int,
 	input: bytes
 ) -> int:
-    length_ceiling = len(input) + word_size - 1
-    words = length_ceiling // word_size
+    length_ceiling = len(input) + EVM_WORD_SIZE - 1
+    words = length_ceiling // EVM_WORD_SIZE
     return base + words * per_word
 
 def price_sha3_variant(input: bytes) -> int:
-    return price_word_metered_hash(30, 6, 64, input)
+    return price_word_metered_hash(30, 6, input)
 
 def price_sha2_512(input: bytes) -> int:
-    return price_word_metered_hash(60, 12, 64, input)
+    return price_word_metered_hash(60, 12, input)
 ```
 
 ## Rationale
@@ -178,26 +179,27 @@ low.
 
 ## Test Cases
 
-* To follow.
+- To follow.
 
 ## Implementation
 
-* [Branch](https://github.com/prestwich/celo-blockchain/tree/prestwich/cip-0020)
+- [Branch](https://github.com/prestwich/celo-blockchain/tree/prestwich/cip-0020)
 
 ## Security Considerations
 
 - This is a permanent departure from compatibility with the Ethereum EVM, and
-its functionality ought to be wrapped in a Celo-specific contract to prevent
-accidental use in an Ethereum-targeted contract.
+  its functionality ought to be wrapped in a Celo-specific contract to prevent
+  accidental use in an Ethereum-targeted contract.
 
 - Given that this is a pure function exposed at the contract layer, it is
-unlikely to have a significant risk on the consensus or governance processes.
+  unlikely to have a significant risk on the consensus or governance processes.
 
 - Each hash function will need to be priced separately. The pricing function for
-this precompile will grow in complexity over time.
+  this precompile will grow in complexity over time.
 
 - If more than 200 hash functions are merged, the selector space will become
-crowded and we will need to plan to add a second selector byte.
+  crowded and we will need to plan to add a second selector byte.
 
 ## License
+
 This work is licensed under the Apache License, Version 2.0.

--- a/CIPs/cip-0020.md
+++ b/CIPs/cip-0020.md
@@ -134,7 +134,7 @@ error.
 New hash functions MUST include a gas cost function and MUST include benchmarks
 that justify that function. This function SHOULD account for setup costs and
 per-block processing of input. To conform to existing hash function precompile
-and opcode behavior, e recommend they be priced as a base gas cost for the
+and opcode behavior, we recommend they be priced as a base gas cost for the
 invocation plus an amount of gas per EVM word processed.
 
 The initial SHA-3 variants (SHA3-256, SHA3-512, and Keccak-512) will be priced


### PR DESCRIPTION
Resolves the word confusion in the CIP20 specification by standardizing on EVM word size