### PR TITLE
CIP-35: Add a section about implications for adopting new Ethereum transaction formats in the future

### DIFF
--- a/CIPs/cip-0035.md
+++ b/CIPs/cip-0035.md
@@ -93,6 +93,12 @@ The rest of the specification follows from that:
 
 This would not create new security issues, aside from the possibility (inherent in any change) of vulnerabilities resulting from bugs.
 
+## Other Considerations
+
+Another important consideration is that if we adopt this CIP, by adding support for transactions in Ethereum format, we are implicitly making a soft commitment to also support future transaction formats adopted by Ethereum, such as [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718).
+
+The reason is that if users start transacting on Celo using tooling written for Ethereum, if and when these tools are updated to generate transactions in new formats, they will no longer work fully with Celo unless we have also added support for the new format (which would need to be included in a hard fork). This possibility creates implicit pressure for us to add support for new Ethereum transaction formats and to do so in a timely manner.  However, adoption of this CIP should not be seen as a hard commitment to do so, and decisions as to the adoption of any new formats would proceed on a case-by-case basis.
+
 ## License
 
 This work is licensed under the Apache License, Version 2.0.


### PR DESCRIPTION
Adds a section to the CIP-35 draft discussing the implications of adopting the CIP for whether we also adopt any new transaction formats supported by Ethereum in the future.