### PR TITLE
CIP-35: Add paragraph explaining replay protection through EIP-155

### DIFF
--- a/CIPs/cip-0035.md
+++ b/CIPs/cip-0035.md
@@ -94,6 +94,8 @@ The rest of the specification follows from that:
 
 This would not create new security issues, aside from the possibility (inherent in any change) of vulnerabilities resulting from bugs.
 
+It should be noted that this CIP adds support for transactions in Ethereum's transaction format, not for transactions intended for the Ethereum network.  Both Ethereum and Celo use [EIP-155](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md), which provides replay protection by including the network's chain id in a transaction's "signing data". Because of this, a given signed transaction can be valid on Ethereum or on Celo, but never on both.  As an example of how this plays out at the level of user experience: in order to use Metamask with the Celo network, Celo has to be added to Metamask as a custom network, a process which includes specifying the chain id (which is 42220 for Celo's mainnet).  Because of the signing data including the chain id, when Metamask then generates and signs transactions for Celo, they are valid for the Celo network but not valid for the Ethereum network.  Likewise, when it generates and signs transactions for Ethereum, they are not valid for the Celo network.
+
 ## Other Considerations
 
 Another important consideration is that if we adopt this CIP, by adding support for transactions in Ethereum format, we are implicitly making a soft commitment to also support future transaction formats adopted by Ethereum, such as [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718).

--- a/CIPs/cip-0035.md
+++ b/CIPs/cip-0035.md
@@ -92,15 +92,17 @@ The rest of the specification follows from that:
 
 ## Security Considerations
 
-This would not create new security issues, aside from the possibility (inherent in any change) of vulnerabilities resulting from bugs.
+It should be noted that both Ethereum and Celo have long incorporated support for [EIP-155](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md), which provides replay protection by including the network's chain id in a transaction's "signing data", so that the transaction is valid only on the specific network it is intended for (e.g. Ethereum or Celo). As an example of how this plays out at the level of user experience: in order to use Metamask with the Celo network, Celo has to be added to Metamask as a custom network, a process which includes specifying the chain id (which is 42220 for Celo's mainnet). Because of the signing data including the chain id, when Metamask then generates and signs transactions for Celo, they are valid for the Celo network but not valid for the Ethereum network. Likewise, when it generates and signs transactions for Ethereum, they are not valid for the Celo network.
 
-It should be noted that this CIP adds support for transactions in Ethereum's transaction format, not for transactions intended for the Ethereum network.  Both Ethereum and Celo use [EIP-155](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md), which provides replay protection by including the network's chain id in a transaction's "signing data". Because of this, a given signed transaction can be valid on Ethereum or on Celo, but never on both.  As an example of how this plays out at the level of user experience: in order to use Metamask with the Celo network, Celo has to be added to Metamask as a custom network, a process which includes specifying the chain id (which is 42220 for Celo's mainnet).  Because of the signing data including the chain id, when Metamask then generates and signs transactions for Celo, they are valid for the Celo network but not valid for the Ethereum network.  Likewise, when it generates and signs transactions for Ethereum, they are not valid for the Celo network.
+While Ethereum and Celo do also support transactions without replay protection, use of EIP-155's replay protection in blockchain clients and wallets is ubiquitous, so the possibility of a transaction being replayed against the user's wishes is very remote.
+
+Aside from this possibility, this proposal would not create new security issues, aside from the possibility (inherent in any change) of vulnerabilities resulting from bugs.
 
 ## Other Considerations
 
 Another important consideration is that if we adopt this CIP, by adding support for transactions in Ethereum format, we are implicitly making a soft commitment to also support future transaction formats adopted by Ethereum, such as [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718).
 
-The reason is that if users start transacting on Celo using tooling written for Ethereum, if and when these tools are updated to generate transactions in new formats, they will no longer work fully with Celo unless we have also added support for the new format (which would need to be included in a hard fork). This possibility creates implicit pressure for us to add support for new Ethereum transaction formats and to do so in a timely manner.  However, adoption of this CIP should not be seen as a hard commitment to do so, and decisions as to the adoption of any new formats would proceed on a case-by-case basis.
+The reason is that if users start transacting on Celo using tooling written for Ethereum, if and when these tools are updated to generate transactions in new formats, they will no longer work fully with Celo unless we have also added support for the new format (which would need to be included in a hard fork). This possibility creates implicit pressure for us to add support for new Ethereum transaction formats and to do so in a timely manner. However, adoption of this CIP should not be seen as a hard commitment to do so, and decisions as to the adoption of any new formats would proceed on a case-by-case basis.
 
 ## License
 


### PR DESCRIPTION
This adds a paragraph to CIP-35 clarifying that Celo and Ethereum both have replay-protection through EIP-155, so that any individual signed transaction is specific to one chain and can't later also be used on the other chain.