### PR TITLE
CIP-35 clarify replay protection, and update implementation branch link

### DIFF
--- a/CIPs/cip-0035.md
+++ b/CIPs/cip-0035.md
@@ -19,6 +19,8 @@ The key words "MUST", "MUST NOT", "SHOULD", and "MAY" in this document are to be
 
 This CIP adds support for an Ethereum-compatible transactions, which don't include the three fields which are unique to Celo transactions: `feecurrency`, `gatewayfeerecipient`, and `gatewayfee`. This would enable Celo to accept transactions generated and signed by Ethereum wallets and other Ethereum tooling, which would let Celo users and developers choose from a among wider range of tools, and reduce the initial friction for new users coming from the Ethereum ecosystem.
 
+It also makes the existing replay-protection used by Ethereum and Celo (see [EIP-155](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md)) mandatory, ensuring that a transaction intended for one blockchain cannot be replayed on another blockchain.
+
 ## Motivation
 
 - As the older and more mature platform, Ethereum has a much wider range of wallets and tooling compared to Celo. Support for Ethereum-compatible transactions would allow much of this software to work with Celo.
@@ -33,7 +35,12 @@ This change requires activation as part of a hard fork. As of `FORK_BLOCK_NUMBER
 1. Normal Celo transactions
 2. Ethereum-compatible transactions
 
-Note that the Normal Celo transactions format simply represents Celo transactions as they currently exist. The only change to them is an additional field when represented as JSON (see below).
+Further, as of `FORK_BLOCK_NUMBER`, clients MUST reject transactions without [EIP-155](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md) replay protection (see below regarding transaction signing and signature verification).
+
+Note that the Normal Celo transactions format simply represents Celo transactions as they currently exist. The only changes to them are:
+
+1. There is an additional field when represented as JSON (see below).
+2. Replay protection, which was ubiquitous but optional, becomes mandatory.
 
 ### RLP transaction format
 
@@ -48,6 +55,8 @@ For the purpose of transaction signing and of validating transaction signatures,
 
 1. For normal Celo transactions: `(nonce, gasprice, gaslimit, feecurrency, gatewayfeerecipient, gatewayfee, recipient, amount, data, chainid, 0, 0)`
 2. For Ethereum-compatible transactions: `(nonce, gasprice, gaslimit, recipient, amount, data, chainid, 0, 0)`
+
+Note that this includes replay protection using the `chainid`, in accordance with [EIP-155](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md), which becomes required rather than recommended.
 
 ### Transaction validation and processing
 
@@ -84,7 +93,8 @@ The rest of the specification follows from that:
 ## Backwards Compatibility
 
 - Requires activation as part of a hard fork, since it introduces a new transaction format which is not currently valid in Celo.
-- Normal Celo transactions will continue to function as they do currently. As a result, no change will be required in software which generates and signs transactions.
+- Normal Celo transactions with replay protection will continue to function as they do currently. As a result, no change will be required in software which generates and signs replay-protected transactions (which includes all known Celo wallets:x
+). Any custom software which generates transactions without replay protection will have to be updated to use replay protection.
 - Software which parses RLP-encoded transactions will need to add support for parsing Ethereum-compatible transactions, and for signing them or verifying their signatures using the right "signed data" (if signing transactions and verifying signatures is part of its functionality).
 - Software which parses transactions from JSON will need to ensure that it doesn't stop working due to the presence of the new `ethCompatible` field. Depending on the software's functionality, it may need to be updated to make correct use of this new field (e.g. if verifying transaction signatures is part of the software's functionality, it will need to be updated to use the correct "signing data" for the transaction's transaction type).
 - Software which serializes transaction to JSON format should be updated to include the `ethCompatible` field.
@@ -93,9 +103,9 @@ The rest of the specification follows from that:
 
 It should be noted that both Ethereum and Celo have long incorporated support for [EIP-155](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md), which provides replay protection by including the network's chain id in a transaction's "signing data", so that the transaction is valid only on the specific network it is intended for (e.g. Ethereum or Celo). As an example of how this plays out at the level of user experience: in order to use Metamask with the Celo network, Celo has to be added to Metamask as a custom network, a process which includes specifying the chain id (which is 42220 for Celo's mainnet). Because of the signing data including the chain id, when Metamask then generates and signs transactions for Celo, they are valid for the Celo network but not valid for the Ethereum network. Likewise, when it generates and signs transactions for Ethereum, they are not valid for the Celo network.
 
-While Ethereum and Celo do also support transactions without replay protection, use of EIP-155's replay protection in blockchain clients and wallets is ubiquitous, so the possibility of a transaction being replayed against the user's wishes is very remote.
+While Ethereum and Celo, prior to this CIP, also support transactions without replay protection, this CIP makes replay protection mandatory, rendering transaction replay between Ethereum and Celo impossible.
 
-Aside from this possibility, this proposal would not create new security issues, aside from the possibility (inherent in any change) of vulnerabilities resulting from bugs.
+This proposal would not create new security issues, aside from the possibility (inherent in any change) of vulnerabilities resulting from bugs.
 
 ## Other Considerations
 

--- a/CIPs/cip-0035.md
+++ b/CIPs/cip-0035.md
@@ -88,13 +88,12 @@ The rest of the specification follows from that:
 
 ## Implementation
 
-- [Branch](https://github.com/celo-org/celo-blockchain/tree/oneeman/eth-compatible-transactions-poc)
+- [Branch](https://github.com/celo-org/celo-blockchain/tree/oneeman/cip35)
 
 ## Backwards Compatibility
 
 - Requires activation as part of a hard fork, since it introduces a new transaction format which is not currently valid in Celo.
-- Normal Celo transactions with replay protection will continue to function as they do currently. As a result, no change will be required in software which generates and signs replay-protected transactions (which includes all known Celo wallets:x
-). Any custom software which generates transactions without replay protection will have to be updated to use replay protection.
+- Normal Celo transactions with replay protection will continue to function as they do currently. As a result, no change will be required in software which generates and signs replay-protected transactions (which includes all known Celo wallets). Any custom software which generates transactions without replay protection will have to be updated to use replay protection.
 - Software which parses RLP-encoded transactions will need to add support for parsing Ethereum-compatible transactions, and for signing them or verifying their signatures using the right "signed data" (if signing transactions and verifying signatures is part of its functionality).
 - Software which parses transactions from JSON will need to ensure that it doesn't stop working due to the presence of the new `ethCompatible` field. Depending on the software's functionality, it may need to be updated to make correct use of this new field (e.g. if verifying transaction signatures is part of the software's functionality, it will need to be updated to use the correct "signing data" for the transaction's transaction type).
 - Software which serializes transaction to JSON format should be updated to include the `ethCompatible` field.


### PR DESCRIPTION
The CIP35 specs state that replay protection must be used.  This constitutes a change from pre-Donut behavior, but is desirable since all known Celo wallets use replay protection already.  This PR updates the CIP35 spec to make clear that this constitutes a breaking change which will take place at hard fork activation.

It also updates the implementation link from the proof-of-concept branch to point instead to the final implementation branch.