### PR TITLE
Update Donut CIP with Baklava activation block number

### DIFF
--- a/CIPs/cip-0027.md
+++ b/CIPs/cip-0027.md
@@ -1,10 +1,10 @@
 ---
 cip: 27
-title: Donut Hardfork 
+title: Donut Hardfork
 author: Yaz Khoury <@YazzyYaz>, James Prestwich <@prestwich>, Kobi Gurkan <@kobigurk>
-discussions-to: https://github.com/celo-org/celo-proposals/issues/94 
+discussions-to: https://github.com/celo-org/celo-proposals/issues/94
 status: Accepted
-type: Meta 
+type: Meta
 created: 2020-11-10
 license: Apache 2.0
 ---
@@ -23,7 +23,7 @@ named by the community as _Donut_.
 This hardfork includes pre-Berlin EIPs like simple EVM subroutines and gas cost increases for state access opcodes, as well as BLS precompiles and extensible hash-function precompiles.
 
 This document proposes the following blocks at which to implement these changes in the Celo networks:
-- `TBD` on Baklava Testnet ()
+- `5002000` on Baklava Testnet (April 13, 2021)
 - `TBD` on Alfajores Testnet ()
 - `TBD` on Celo Mainnet ()
 For more information on the opcodes and their respective EIPs and CIP implementations, please see the _Specification_


### PR DESCRIPTION
The block number has been set in celo-blockchain: https://github.com/celo-org/celo-blockchain/pull/1472.  This PR updates the CIP to include the block number as well.

It also includes some trailing whitespace cleanup my IDE did automatically.