### PR TITLE
[CGP-28] Initial draft for CGP to initialize the uptime lookback window blockchain parameter

### DIFF
--- a/CGPs/0028.md
+++ b/CGPs/0028.md
@@ -1,0 +1,44 @@
+# CGP [0028]: Initialize uptime lookback window
+
+- Date: 2021-04-26
+- Author(s): @oneeman
+- Status: DRAFT
+- Governance Proposal ID #: TBD
+- Date Executed: TBD
+
+## Overview
+
+The Donut hard fork (to be activated on Mainnet on May 19, 2021) includes [CIP-28](https://github.com/celo-org/celo-proposals/blob/master/CIPs/cip-0028.md), which makes the validator's uptime lookback window governable via the `BlockchainParameters` contract. The corresponding upgrade to the contract has already been deployed as part of Contracts Release 3.
+
+This proposal would initialize the uptime lookback window on the contract, setting its value to 12, which is the size of the lookback window in the celo-blockchain client prior to Donut's activation.
+
+The choice of 12 as the value to set it to means that there would be no effect on validator uptime calculations compared to the state pre-Donut. Given the validator grace period introduced in [CIP-29](https://github.com/celo-org/celo-proposals/blob/master/CIPs/cip-0029.md)  and [CGP-27](https://github.com/celo-org/celo-proposals/blob/master/CGPs/0027.md), there doesn't seem to be a pressing need for a different value. The initialization proposed here would be done so that contract calls in celo-blockchain to get the lookback window size can succeed.
+
+If the lookback window is not initialized prior to Donut activation, these contract calls would give the error `UptimeLookbackWindow is not initialized`. The celo-blockchain client has handling in place for such an error, to instead use the default value of 12, so there is no risk to the network in leaving it uninitialized. When Donut was activated on Baklava, the lookback window had not been initialized, and no problems resulted. However, the error from the contract in such a case gets logged, which would constitute undesirable additional noise in nodes' logs. For this reason, initializing the lookback window prior to Donut activation is preferable.
+
+If a different value for the uptime lookback window is subsequently felt to be desirable, it can be set using a separate governance proposal.
+
+## Proposed Changes
+
+1. Initialize the uptime lookback window to 12
+    - Destination: `BlockchainParameters`
+    - Function: `setUptimeLookbackWindow`
+    - Arguments: `["12"]`
+    - Value: `0`
+
+The proposal's json may be seen [here](https://github.com/celo-org/celo-proposals/blob/master/CGPs/0028/mainnet.json).
+
+## Verification
+
+TODO
+
+## Risks
+
+No known risks. The proposal merely initializes a parameter of the `BlockchainParameters` contract as the contract was designed to handle. Analogous proposals have already been passed and executed on Baklava and Alfajores (where the lookback window was set to 20 rather than 12 in order to confirm in subsequent testing that this different value has come into effect).
+
+## Useful Links
+
+* [CIP-28 (governable lookback window)](https://github.com/celo-org/celo-proposals/blob/master/CIPs/cip-0028.md)
+* [This proposal's JSON](https://github.com/celo-org/celo-proposals/blob/master/CGPs/0028/mainnet.json)
+* [CIP-29 (grace period)](https://github.com/celo-org/celo-proposals/blob/master/CIPs/cip-0029.md)
+* [CGP-27 (setting the grace period)](https://github.com/celo-org/celo-proposals/blob/master/CGPs/0027.md)

--- a/CGPs/0028/mainnet.json
+++ b/CGPs/0028/mainnet.json
@@ -1,0 +1,1 @@
+[{"contract":"BlockchainParameters","function":"setUptimeLookbackWindow","args":["12"],"value":"0"}]


### PR DESCRIPTION
PR for a CGP for initializing the uptime lookback window parameter on the `BlockchainParameters` contract, in preparation for the Donut hard fork.  It initializes it to 12, which is the same as the default value and the value used pre-Donut.

Note the link below to the proposal's JSON won't work until this is merged, since it references the master branch.  But the contents of the json can be seen in the PR's changes.

I chose number 28 for this CGP based on what I saw on this repo as of now.  We can change the CGP number if needed.