### PR TITLE
[CGP 0029P] - Increase the number of validators to 110

### DIFF
--- a/CGPs/0029.md
+++ b/CGPs/0029.md
@@ -1,0 +1,34 @@
+# CGP [0028]: Increase Validator Set Size
+
+- Date: 2021-04-26
+- Author(s): @trianglesphere
+- Status: PROPOSED
+- Governance Proposal ID #: ??
+- Date Executed: [if executed]
+- Discussions To: [todo]
+
+## Overview
+
+This CGP proposes increasing the elected validator set size from 100 to 110. This change would allow more validator groups and up to ten more validators to register and participate in consensus.
+
+The motivation for this change is to embark on the process of increasing the elected validator set that Celo can support. There has been tremendous demand to validate on Celo from the community, and due to the limitation of only supporting 100 validators currently elected, much of this interest is not able to be supported.
+
+The additional validators would each be eligible to receive the current validator rewards (up to 75k cUSD per annum), and the total protocol payout would increase accordingly
+
+## Proposed Changes
+
+TODO
+
+## Verification
+
+1. Confirm proposal: run `celocli governance:view --proposalID <proposalID>`
+2. Confirm Execution: run `celocli network:parameters --node https://forno.celo.org`
+
+## Risks
+
+- Given the current elected validator set, vote minimums will shift that current validator groups end up claiming the additional seats, without allowing for any new entrants.
+- If the CELO:cUSD rate changes, the protocol payout may change from being under-target, to over-target
+
+## Useful Links
+
+- TODO

--- a/CGPs/0029.md
+++ b/CGPs/0029.md
@@ -17,7 +17,13 @@ The additional validators would each be eligible to receive the current validato
 
 ## Proposed Changes
 
-TODO
+The minimum and maximum number of electable validators can be set in the elections contract.
+22 is the current minimum number of validators. We propose not changing that.
+The maximum number of validators will be raised from 100 to 110.
+```
+// Elections contract
+setElectableValidators(22, 110)
+```
 
 ## Verification
 

--- a/CGPs/0029.md
+++ b/CGPs/0029.md
@@ -2,7 +2,7 @@
 
 - Date: 2021-04-26
 - Author(s): @trianglesphere
-- Status: PROPOSED
+- Status: DRAFT
 - Governance Proposal ID #: ??
 - Date Executed: [if executed]
 - Discussions To: [todo]

--- a/CGPs/0029.md
+++ b/CGPs/0029.md
@@ -1,4 +1,4 @@
-# CGP [0028]: Increase Validator Set Size
+# CGP [0029]: Increase Validator Set Size
 
 - Date: 2021-04-26
 - Author(s): @trianglesphere


### PR DESCRIPTION
### Overview

Increase the maximum number of electable validators from 100 to 110.