### PR TITLE
[CIP 0039] Move CIP-39 file and fix spelling errors

### DIFF
--- a/CIPs/cip-0039.md
+++ b/CIPs/cip-0039.md
@@ -30,7 +30,7 @@ Adding error correcting codes to the mnemonic phrase would allow for correction 
 of arbitrary errors. This CIP proposes a fully-compatible extension to BIP-39 in which some of the
 random words are replaced with "error correcting" words to produce an instance of
 [Reed-Solomon](https://en.wikipedia.org/wiki/Reed%E2%80%93Solomon_error_correction) coding. It is
-constructed as a subset of BIP-39, allowing CIP-# and plain BIP-39 phrases to be used
+constructed as a subset of BIP-39, allowing CIP-39 and plain BIP-39 phrases to be used
 interchangeable in existing and new applications.
 
 ## Motivation
@@ -119,7 +119,7 @@ that of the `N` words, any `K` uniquely determine the remaining `N-K`. Of the po
 Each BIP-39 phrase has 1 bit of checksum per three words, and is a uniform random function of the
 phrase. As a result, each selection of `K` words has a probability of `2^(-N/3)` producing a valid
 checksum, effectively reducing the set of possible phrases by that factor. Therefore, there are a
-total of `2^(11*K - N/3)` valid phrases in the set of CIP-# phrases with a fixed `N` and `K`. When
+total of `2^(11*K - N/3)` valid phrases in the set of CIP-39 phrases with a fixed `N` and `K`. When
 generating a phrase, one of these is chosen with uniform random probability, resulting in `11*K -
 N/3` bits of entropy, which is up to 4 bits less than a BIP-39 phrase of length `K`.
 
@@ -163,17 +163,17 @@ mnemonic with error correction:
 * If the result of error correction is a different phrase, then the given phrase contained at least
   one error, but was recovered successfully. 
   * Note that error correction will change at most `floor((N - K) / 2)` unknown positions.
-* If error correction fails, then the phrase is either not a CIP-# phrase, or has too many errors to
+* If error correction fails, then the phrase is either not a CIP-39 phrase, or has too many errors to
   fix.
 
 <!-- TODO(victor) Analyse the probability of this kind of failure. Its likely similar to the issue
-of mistakenly identifying a plain BIP-39 phrase as a CIP-# phrase, which is described below. -->
+of mistakenly identifying a plain BIP-39 phrase as a CIP-39 phrase, which is described below. -->
 Note that if the given phrase contains more than `floor((N - K) / 2)`, then there is a small
 probability that error correction will report success and return a phrase different than the true
 source phrase. Given the chance of mistaken "correction" of a phrase, applications SHOULD inform
 the user before proceeding with a phrase altered by this error correction procedure.
 
-#### Acceptance of plain BIP-39 phrases by CIP-# applications
+#### Acceptance of plain BIP-39 phrases by CIP-39 applications
 
 Applications that implement this proposal SHOULD also accept plain BIP-39 phrases. A phrase SHOULD
 be treated as a plain BIP-39 phrase if error correction fails and the given phrase has a valid
@@ -182,11 +182,11 @@ correction, it is very unlikely.
 
 ## Rationale
 
-### Probability of mistaken identification of a plain BIP-39 phrase as a CIP-# phrase
+### Probability of mistaken identification of a plain BIP-39 phrase as a CIP-39 phrase
 
 Described above, error correction and a checksum validation are used to determine if error
 correction is available. It is technically possible, but unlikely, for this to mistake a plain BIP-39
-phrase for a CIP-# phrase. Specifically, given a plain BIP-39 phrase of `N` words, `e` of which are
+phrase for a CIP-39 phrase. Specifically, given a plain BIP-39 phrase of `N` words, `e` of which are
 invalid (i.e. erasures), the probability that the phrase will pass error correction is equal to the
 probability that:
 
@@ -211,12 +211,12 @@ with `y` defined above.
 
 If the phrase decodes, it will then be re-encoded and the checksum will be verified. Assuming the
 phrase was modified by the re-encoding procedure, the probability that the checksum will verify is
-`2^(-N/3)`. Overall the chance of mistaking a plain BIP-39 phrase for a CIP-# phrase is `(1 - (1 -
+`2^(-N/3)`. Overall the chance of mistaking a plain BIP-39 phrase for a CIP-39 phrase is `(1 - (1 -
 y) ^ ((N - e) choose ceil((N + K - e) / 2))) * 2^(-N/3)`.
 
-Given a correct 15-word plain BIP-39 phrase, the probability of mistaking it for a CIP-# phrase is
+Given a correct 15-word plain BIP-39 phrase, the probability of mistaking it for a CIP-39 phrase is
 roughly 1 in 10 million. If the 15-word phrase has an invalid word (i.e. an erasure), it will be
-mistaken for a CIP-# phrase with probability roughly 2 in 10,000. For all larger values of `N` and
+mistaken for a CIP-39 phrase with probability roughly 2 in 10,000. For all larger values of `N` and
 `K`, and with any number of erasures, the probability is lower. In most cases this is negligible,
 but does reinforce the recommendation that the application inform users before proceeding with a
 phrase altered by error correction.
@@ -242,8 +242,8 @@ WIP
 
 * As with any proposal handling the source material for key generation, mistakes in implementation
   can lead to loss of funds or leakage of key material.
-* Users understanding BIP-39 security levels may misinterpret an `N` word CIP-# phrase to have a
-  higher security level than it actually does. (I.e. Assuming a 24-word CIP-# phrase has 256 bits
+* Users understanding BIP-39 security levels may misinterpret an `N` word CIP-39 phrase to have a
+  higher security level than it actually does. (I.e. Assuming a 24-word CIP-39 phrase has 256 bits
   of entropy, when it may have between 124 and 223 bits, depending on selection of `K`)
 
 ## License

--- a/CIPs/cip-0039.md
+++ b/CIPs/cip-0039.md
@@ -46,18 +46,18 @@ to paper, during storage (e.g. water damage, dog nibbled on it), or when typing 
 wallet application, the raw data (i.e. entropy) may still be available in the key, but has been
 obscured by the introduced errors. Given expertise and time, a user may being able to manually
 locate and remove any errors present in the phrase. Most users don't have the required expertise or
-time. Hueristic-based techinques, such as suggesting phrases that have a low edit distance from the
-origonal, provide an option to correct phrases with common errors such as typos or substitution for
-simmilar words. https://github.com/celo-org/celo-monorepo/pull/8034 provides an example of how to do
+time. Heuristic-based techniques, such as suggesting phrases that have a low edit distance from the
+original, provide an option to correct phrases with common errors such as typos or substitution for
+similar words. https://github.com/celo-org/celo-monorepo/pull/8034 provides an example of how to do
 this.
 
 When information is lost from the phrase (e.g. some of the words are entirely missing), or when the
 heuristic does not do appropriately model a particular error, heuristics based approaches may fail.
-Proposed here is the introduction of error correcting codes, which can recover phases with a number
+Proposed here is the introduction of error correcting codes, which can recover phrases with a number
 of arbitrary errors, covering many cases that model based approaches cannot.
 
-Compared to heursistc based methods, this method can handle a larger class of errors without making
-modelling assumptions, such as assuming phrase are mutated by a small set of edit operations. It can
+Compared to heuristic based methods, this method can handle a larger class of errors without making
+modeling assumptions, such as assuming phrase are mutated by a small set of edit operations. It can
 also be used complimentary to heuristic based approaches. As a cost for this benefit is higher
 complexity in implementation and the fact that this method can only be applied to new phrases.
 
@@ -120,7 +120,7 @@ Each BIP-39 phrase has 1 bit of checksum per three words, and is a uniform rando
 phrase. As a result, each selection of `K` words has a probability of `2^(-N/3)` producing a valid
 checksum, effectively reducing the set of possible phrases by that factor. Therefore, there are a
 total of `2^(11*K - N/3)` valid phrases in the set of CIP-# phrases with a fixed `N` and `K`. When
-generating a phrase, one of these is chosen with uniform random probabilty, resulting in `11*K -
+generating a phrase, one of these is chosen with uniform random probability, resulting in `11*K -
 N/3` bits of entropy, which is up to 4 bits less than a BIP-39 phrase of length `K`.
 
 #### Generation


### PR DESCRIPTION
Minor edits to CIP-39:

* Moves the file from CIPs/cip-39.md to CIP/cip-0039.md
* Fix a number of spelling errors