### PR TITLE
Tobikuhlmann/correct adjustment factor

### DIFF
--- a/CGPs/0033.md
+++ b/CGPs/0033.md
@@ -17,12 +17,12 @@ The dynamic target voting reward rate adjustment factor adjusts the target votin
 
 Parameter Details:
 
-- targetVotingYieldParams.adjustmentFactor: 0 --> 0.00000119250
+- targetVotingYieldParams.adjustmentFactor: 0 --> 0.00000112799
 - targetVotingYieldParams.max: unchanged 0.0005 ((x + 1) ^ 365 = 1.20)
 
-The size of the staking reward rate adjustment in every epoch is calculated by multiplying the difference of the voting percentage and the target voting percentage with the `adjustmentFactor`. With a target voting percentage of '60%' or '0.6' as proposed in CGP 34, the maximum distance from target is $0.6$. With the proposed `adjustmentFactor` of `0.00000119250`, the largest possible change of the annualized staking reward rate over the course of one year therefore is `(1 + 0.6  * 365 * 0.00000119250)^{365} - 1 = 0.0999998 ~ 10%`. This would only occur if the voting percentage would reside at the extreme of 0% at every epoch of the year. 
+The size of the staking reward rate adjustment in every epoch is calculated by multiplying the difference of the voting percentage and the target voting percentage with the `adjustmentFactor`. With a target voting percentage of `60%` or `0.6` as proposed in CGP 34, the maximum distance from target is `0.6`. With the proposed `adjustmentFactor` of `0.00000112799`, the largest possible change of the annualized staking reward rate over the course of one year therefore is `(1.00016 + 0.6 * 365 * 0.00000112799)^{365} - (1.00016)^{365} = 0.1 = 10%`. This would only occur if the voting percentage would reside at the extreme of 0% at every epoch of the year. 
 
-Since the current voting percentage is at ~60% and the target 50% (If GCP 34 to increase target to 60% would not pass), the target reward rate would reduce from 6% to ~4.4% over the course of one year, if voting participation would stay constant at 60%. ('(1 - 0.1 * 365 * 0.00000119250)^{365} - 1 = -0.0157619'). 
+Since the current voting percentage is at ~60% and the target 50% (If GCP 34 to increase target to 60% would not pass), the target reward rate would reduce from 6% to ~4.5% over the course of one year, if voting participation would stay constant at 60%. ('(1 - 0.1 * 365 * 0.00000112799)^{365} - 1 = -0.0149156'). 
 
 If CGP 34 passes and the target voting percentage increases to 60%, almost no adjustment is expected when the actual voting percentage remains at ~60%.
 
@@ -35,7 +35,7 @@ The related `targetVotingYieldParams` parameter `max`, which provides an upper b
   - Destination: EpochRewards, [setTargetVotingYieldParameters](https://github.com/celo-org/celo-monorepo/blob/master/packages/protocol/contracts/governance/EpochRewards.sol#L293)
   - Data: 
     - max = 500000000000000000000 (0.0005 * 10^24)
-    - adjustmentFactor = 1192500000000000000 (0.00000119250 * 10^24)
+    - adjustmentFactor = 1127990000000000000 (0.00000112799 * 10^24)
   - Value: 0 (NA)
 
 

--- a/CGPs/0033.md
+++ b/CGPs/0033.md
@@ -46,8 +46,8 @@ https://explorer.celo.org/address/0x07F007d389883622Ef8D4d347b3f78007f28d8b7/rea
 
 
 ## Risks
-- Voting participation could be too sensitive to target voting yield changes. The value of 'adjustmentFactor' could be too large in that case. However, the opposite has been the case so far: Voting yield has decreased from 0.06 to 0.053 and voting CELO fraction has been increasing from ~0.5 at epoch 50 to ~0.6 at epoch 400
-- Voting participation might not be sensitive enough. The value of 'adjustmentFactor' could be too small in that case to effectively increase voting participation when it’s dropping. In that case, however, a small adjustmentFactor would be better than none at all, as it is currently.
+- Voting participation could be too sensitive to target voting yield changes. The value of `adjustmentFactor` could be too large in that case. However, the opposite has been the case so far: Voting reward rate has decreased from 0.06 to 0.053 and voting CELO fraction has been increasing from ~0.5 at epoch 50 to ~0.6 at epoch 400
+- Voting participation might not be sensitive enough. The value of `adjustmentFactor` could be too small in that case to effectively increase voting participation when it’s dropping. In that case, however, a small adjustmentFactor would be better than none at all, as it is currently.
 
 
 ## Useful Links

--- a/CGPs/0033.md
+++ b/CGPs/0033.md
@@ -46,8 +46,8 @@ https://explorer.celo.org/address/0x07F007d389883622Ef8D4d347b3f78007f28d8b7/rea
 
 
 ## Risks
-- Voting participation could be too sensitive to target voting yield changes. The value of 'adjustmentFactor=0.00000119250' could be too large in that case. However, the opposite has been the case so far: Voting yield has decreased from 0.06 to 0.053 and voting CELO fraction has been increasing from ~0.5 at epoch 50 to ~0.6 at epoch 400
-- Voting participation might not be sensitive enough. The value of 'adjustmentFactor=0.00000119250' could be too small in that case to effectively increase voting participation when it’s dropping. In that case, however, a small adjustmentFactor would be better than none at all, as it is currently.
+- Voting participation could be too sensitive to target voting yield changes. The value of 'adjustmentFactor' could be too large in that case. However, the opposite has been the case so far: Voting yield has decreased from 0.06 to 0.053 and voting CELO fraction has been increasing from ~0.5 at epoch 50 to ~0.6 at epoch 400
+- Voting participation might not be sensitive enough. The value of 'adjustmentFactor' could be too small in that case to effectively increase voting participation when it’s dropping. In that case, however, a small adjustmentFactor would be better than none at all, as it is currently.
 
 
 ## Useful Links

--- a/CGPs/0033.md
+++ b/CGPs/0033.md
@@ -46,8 +46,8 @@ https://explorer.celo.org/address/0x07F007d389883622Ef8D4d347b3f78007f28d8b7/rea
 
 
 ## Risks
-- Voting participation could be too sensitive to target voting yield changes. The value of adjustmentFactor=1/1825 could be too large in that case. However, the opposite has been the case so far: Voting yield has decreased from 0.06 to 0.053 and voting CELO fraction has been increasing from ~0.5 at epoch 50 to ~0.6 at epoch 400
-- Voting participation might not be sensitive enough. The value of adjustmentFactor=1/1825 could be too small in that case to effectively increase voting participation when it’s dropping. In that case, however, a small adjustmentFactor would be better than none at all, as it is currently.
+- Voting participation could be too sensitive to target voting yield changes. The value of 'adjustmentFactor=0.00000119250' could be too large in that case. However, the opposite has been the case so far: Voting yield has decreased from 0.06 to 0.053 and voting CELO fraction has been increasing from ~0.5 at epoch 50 to ~0.6 at epoch 400
+- Voting participation might not be sensitive enough. The value of 'adjustmentFactor=0.00000119250' could be too small in that case to effectively increase voting participation when it’s dropping. In that case, however, a small adjustmentFactor would be better than none at all, as it is currently.
 
 
 ## Useful Links

--- a/CGPs/0033.md
+++ b/CGPs/0033.md
@@ -20,7 +20,7 @@ Parameter Details:
 - targetVotingYieldParams.adjustmentFactor: 0 --> 0.00000119250
 - targetVotingYieldParams.max: unchanged 0.0005 ((x + 1) ^ 365 = 1.20)
 
-The size of the staking reward rate adjustment in every epoch is calculated by multiplying the difference of the voting percentage and the target voting percentage with the `adjustmentFactor`. With a target voting percentage of '60%' or '0.6' as proposed in CGP 34, the maximum distance from target is $0.6$. With the proposed `adjustmentFactor` of `0.00000119250`, the largest possible change of the staking reward rate over the course of one year therefore is `(1 + 0.6  * 365 * 0.00000119250)^{365} - 1 = 0.0999998 ~ 10%`. This would only occur if the voting percentage would reside at the extreme of 0% at every epoch of the year. 
+The size of the staking reward rate adjustment in every epoch is calculated by multiplying the difference of the voting percentage and the target voting percentage with the `adjustmentFactor`. With a target voting percentage of '60%' or '0.6' as proposed in CGP 34, the maximum distance from target is $0.6$. With the proposed `adjustmentFactor` of `0.00000119250`, the largest possible change of the annualized staking reward rate over the course of one year therefore is `(1 + 0.6  * 365 * 0.00000119250)^{365} - 1 = 0.0999998 ~ 10%`. This would only occur if the voting percentage would reside at the extreme of 0% at every epoch of the year. 
 
 Since the current voting percentage is at ~60% and the target 50% (If GCP 34 to increase target to 60% would not pass), the target reward rate would reduce from 6% to ~4.4% over the course of one year, if voting participation would stay constant at 60%. ('(1 - 0.1 * 365 * 0.00000119250)^{365} - 1 = -0.0157619'). 
 

--- a/CGPs/0033.md
+++ b/CGPs/0033.md
@@ -9,7 +9,7 @@
 
 ## Overview
 
-This change activates dynamic staking reward rate adjustment by setting the staking yield `adjustmentFactor` to a positive value of 0.00000119250. Currently the staking reward rate `adjustmentFactor` is at zero which keeps the staking reward rate constant at 6%. 
+This change activates dynamic staking reward rate adjustment by setting the staking yield `adjustmentFactor` to a positive value of 0.00000112799. Currently the staking reward rate `adjustmentFactor` is at zero which keeps the staking reward rate constant at 6%. 
 
 Staking and voting in Celo competes with other uses for the CELO token. With competing reward opportunities like Ubeswap yield farming for CELO evolving, it is becoming more and more important that the voting reward rate can adjust quickly to ensure reasonable voter participation, as we may see the voting participation drop. It is important for the security of the network for staking to be sufficiently attractive, and the dynamic voting reward rate adjustment ensures so. 
 

--- a/CGPs/0033.md
+++ b/CGPs/0033.md
@@ -20,9 +20,9 @@ Parameter Details:
 - targetVotingYieldParams.adjustmentFactor: 0 --> 0.00000119250
 - targetVotingYieldParams.max: unchanged 0.0005 ((x + 1) ^ 365 = 1.20)
 
-The size of the staking reward rate adjustment in every epoch is calculated by multiplying the difference of the voting percentage and the target voting percentage with the `adjustmentFactor`. With a target voting percentage of $60\%$ or $0.6$ as proposed in CGP 34, the maximum distance from target is $0.6$. With the proposed `adjustmentFactor` of `0.00000119250`, the largest possible change of the staking reward rate over the course of one year therefore is `(1 + 0.6  * 365 * 0.00000119250)^{365} - 1 = 0.0999998 ~ 10%`. This would only occur if the voting percentage would reside at the extreme of 0% at every epoch of the year. 
+The size of the staking reward rate adjustment in every epoch is calculated by multiplying the difference of the voting percentage and the target voting percentage with the `adjustmentFactor`. With a target voting percentage of '60%' or '0.6' as proposed in CGP 34, the maximum distance from target is $0.6$. With the proposed `adjustmentFactor` of `0.00000119250`, the largest possible change of the staking reward rate over the course of one year therefore is `(1 + 0.6  * 365 * 0.00000119250)^{365} - 1 = 0.0999998 ~ 10%`. This would only occur if the voting percentage would reside at the extreme of 0% at every epoch of the year. 
 
-Since the current voting percentage is at ~60% and the target 50% (If GCP 34 to increase target to 60% would not pass), the target reward rate would reduce from 6% to ~4.4% over the course of one year, if voting participation would stay constant at 60%. ((1 - 0.1 * 365 * 0.00000119250)^{365} - 1 = -0.0157619). 
+Since the current voting percentage is at ~60% and the target 50% (If GCP 34 to increase target to 60% would not pass), the target reward rate would reduce from 6% to ~4.4% over the course of one year, if voting participation would stay constant at 60%. ('(1 - 0.1 * 365 * 0.00000119250)^{365} - 1 = -0.0157619'). 
 
 If CGP 34 passes and the target voting percentage increases to 60%, almost no adjustment is expected when the actual voting percentage remains at ~60%.
 

--- a/CGPs/0033.md
+++ b/CGPs/0033.md
@@ -1,4 +1,4 @@
-# CGP 0033: Activate Dynamic Voting Yield Adjustment Factor
+# CGP 0033: Activate Dynamic Voting Reward Rate Adjustment Factor
 
 - Date: 2021-06-29
 - Author(s): @tobikuhlmann

--- a/CGPs/0033.md
+++ b/CGPs/0033.md
@@ -9,18 +9,22 @@
 
 ## Overview
 
-This change activates dynamic staking yield adjustment by setting the staking yield `adjustmentFactor` to a positive value of 1/1825. Currently the staking yield `adjustmentFactor` is at zero which keeps the staking yield constant at 6%. 
+This change activates dynamic staking reward rate adjustment by setting the staking yield `adjustmentFactor` to a positive value of 0.00000119250. Currently the staking reward rate `adjustmentFactor` is at zero which keeps the staking reward rate constant at 6%. 
 
-Staking and voting in Celo competes with other uses for the CELO token. With competing yield opportunities like Ubeswap yield farming for CELO evolving, it is becoming more and more important that the voting yield can adjust quickly to ensure reasonable voter participation, as we may see the voting participation drop. It is important for the security of the network for staking to be sufficiently attractive, and the dynamic voting yield adjustment ensures so. 
+Staking and voting in Celo competes with other uses for the CELO token. With competing reward opportunities like Ubeswap yield farming for CELO evolving, it is becoming more and more important that the voting reward rate can adjust quickly to ensure reasonable voter participation, as we may see the voting participation drop. It is important for the security of the network for staking to be sufficiently attractive, and the dynamic voting reward rate adjustment ensures so. 
 
-The dynamic target voting yield adjustment factor adjusts the target voting yield automatically based on deviation of actual voting CELO fraction to target voting CELO fraction in every epoch. The target voting percentage is currently set to 50%, with the actual voting percentage being ~60%. If the voting percentage is below the target at the end of an epoch, the staking yield is increased; if the voting percentage is above the target at the end of an epoch, the staking yield is decreased.
+The dynamic target voting reward rate adjustment factor adjusts the target voting reward rate automatically based on deviation of actual voting CELO fraction to target voting CELO fraction in every epoch. The target voting percentage is currently set to 50%, with the actual voting percentage being ~60%.  CGP 34 proposes to increase the voting percentage target to 60%. If the voting percentage is below the target at the end of an epoch, the staking reward rate is increased; if the voting percentage is above the target at the end of an epoch, the staking reward rate is decreased.
 
 Parameter Details:
 
-- targetVotingYieldParams.adjustmentFactor: 0 --> 1 / 1825  (or 0,0005479452055)
+- targetVotingYieldParams.adjustmentFactor: 0 --> 0.00000119250
 - targetVotingYieldParams.max: unchanged 0.0005 ((x + 1) ^ 365 = 1.20)
 
-The size of the staking yield adjustment in every epoch is calculated by multiplying the difference of the voting percentage and the target voting percentage with the `adjustmentFactor`. With a target voting percentage of 50%, the maximum distance is +/- 50%. With the proposed `adjustmentFactor` of `1/1825`, the largest possible change of the staking yield over the course of one year therefore is `+/- 50% * 1/1825 * 365 = +/- 10%` which would only occur if the voting percentage would reside at the extremes of 0% or 100% at every day of the year. Since the current voting percentage is at ~60% and the target 50%, the target voting yield would reduce from 6% to 4% over 12 months if voting participation would stay constant at 60%. (-10% * 1/1825 * 365 = - 2%).
+The size of the staking reward rate adjustment in every epoch is calculated by multiplying the difference of the voting percentage and the target voting percentage with the `adjustmentFactor`. With a target voting percentage of $60\%$ or $0.6$ as proposed in CGP 34, the maximum distance from target is $0.6$. With the proposed `adjustmentFactor` of `0.00000119250`, the largest possible change of the staking reward rate over the course of one year therefore is `(1 + 0.6  * 365 * 0.00000119250)^{365} - 1 = 0.0999998 ~ 10%`. This would only occur if the voting percentage would reside at the extreme of 0% at every epoch of the year. 
+
+Since the current voting percentage is at ~60% and the target 50% (If GCP 34 to increase target to 60% would not pass), the target reward rate would reduce from 6% to ~4.4% over the course of one year, if voting participation would stay constant at 60%. ((1 - 0.1 * 365 * 0.00000119250)^{365} - 1 = -0.0157619). 
+
+If CGP 34 passes and the target voting percentage increases to 60%, almost no adjustment is expected when the actual voting percentage remains at ~60%.
 
 The related `targetVotingYieldParams` parameter `max`, which provides an upper bound above which the staking yield would not be increased dynamically, remains unchanged (at 20% annually) by this proposal.
 
@@ -31,7 +35,7 @@ The related `targetVotingYieldParams` parameter `max`, which provides an upper b
   - Destination: EpochRewards, [setTargetVotingYieldParameters](https://github.com/celo-org/celo-monorepo/blob/master/packages/protocol/contracts/governance/EpochRewards.sol#L293)
   - Data: 
     - max = 500000000000000000000 (0.0005 * 10^24)
-    - adjustmentFactor = 547 945 205 500 000 000 000 (0,0005479452055 * 10^24)
+    - adjustmentFactor = 1192500000000000000 (0.00000119250 * 10^24)
   - Value: 0 (NA)
 
 

--- a/CGPs/0033.md
+++ b/CGPs/0033.md
@@ -22,7 +22,7 @@ Parameter Details:
 
 The size of the staking reward rate adjustment in every epoch is calculated by multiplying the difference of the voting percentage and the target voting percentage with the `adjustmentFactor`. With a target voting percentage of `60%` or `0.6` as proposed in CGP 34, the maximum distance from target is `0.6`. With the proposed `adjustmentFactor` of `0.00000112799`, the largest possible change of the annualized staking reward rate over the course of one year therefore is `(1.00016 + 0.6 * 365 * 0.00000112799)^{365} - (1.00016)^{365} = 0.1 = 10%`. This would only occur if the voting percentage would reside at the extreme of 0% at every epoch of the year. 
 
-Since the current voting percentage is at ~60% and the target 50% (If GCP 34 to increase target to 60% would not pass), the target reward rate would reduce from 6% to ~4.5% over the course of one year, if voting participation would stay constant at 60%. ('(1 - 0.1 * 365 * 0.00000112799)^{365} - 1 = -0.0149156'). 
+Since the current voting percentage is at ~60% and the target 50% (If GCP 34 to increase target to 60% would not pass), the target reward rate would reduce from 6% to ~4.4% over the course of one year, if voting participation would stay constant at 60%. `(1.00016 - 0.1 * 365 * 0.00000112799)^{365} - (1.00016)^{365} = -0.01581`. 
 
 If CGP 34 passes and the target voting percentage increases to 60%, almost no adjustment is expected when the actual voting percentage remains at ~60%.
 

--- a/CGPs/0033/cgp_0033.json
+++ b/CGPs/0033/cgp_0033.json
@@ -1,1 +1,1 @@
-[{"contract":"EpochRewards","function":"setTargetVotingYieldParameters","args":["500000000000000000000","547945205500000000000"],"value":"0"}]
+[{"contract":"EpochRewards","function":"setTargetVotingYieldParameters","args":["500000000000000000000","1127990000000000000"],"value":"0"}]


### PR DESCRIPTION
This PR corrects the proposed value of the staking reward rate adjustment factor. The math to determine the parameter value has been incorrect and is corrected here. 

Math details can be found here: https://www.notion.so/clabsco/Parameter-value-choice-Dynamic-target-voting-yield-adjustment-factor-147ef4f44c894bf797ac59d736be021a