### PR TITLE
[CIP-40] Add optional quota status and disable domain APIs

### DIFF
--- a/CIPs/cip-0040.md
+++ b/CIPs/cip-0040.md
@@ -13,7 +13,6 @@ license: Apache 2.0
 
 ### Terminology
 
-<!-- TODO(victor): Actually go through and add these keywords where appropriate -->
 The key words "MUST", "MUST NOT", "SHOULD", and "MAY" in this document are to be interpreted as
 described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119.html).
 
@@ -468,7 +467,6 @@ const domain: LinearBackoffDomain = {
 }
 ```
 
-<!-- TODO(victor) Verify that there are no mistakes in this example. -->
 ```text
 domainSeparator = keccak256(
   keccak256("EIP712Domain(string name,string version)") ||

--- a/CIPs/cip-0040.md
+++ b/CIPs/cip-0040.md
@@ -89,7 +89,7 @@ interface which accepts a domain specifiers, visible to the service, alongside t
 ODIS currently makes available its OPRF function with the following API:
 
 ```typescript
-// POST to /getBlindedMessagePartialSig
+// POST /getBlindedMessagePartialSig
 // Headers:
 //   Content-Type: application/json
 //   Authorization: ${signature from authorized signer (e.g. DEK) for account}
@@ -107,6 +107,16 @@ interface GetBlindedMessageSigRequest {
   // Client-specified session ID.
   sessionID?: string
 }
+
+interface SignMessageResponse {
+  success: boolean
+  error?: string
+  version?: string
+  signature?: string
+  performedQueryCount?: number
+  totalQuota?: number
+  blockNumber?: number
+}
 ```
 
 #### Extension for domain-restricted requests
@@ -114,17 +124,17 @@ interface GetBlindedMessageSigRequest {
 In order to support domain-restricted queries, a new API is proposed:
 
 ```typescript
-// POST to /getDomainRestrictedPartialSig
+// POST /getDomainRestrictedSignature
 // Headers:
 //   Content-Type: application/json
-interface GetDomainRestrictedSigRequest {
+interface DomainRestrictedSignatureRequest {
   // Domain specification.
   // Selects the PRF domain and rate limiting rules.
   domain: Domain
   // Domain-specific options.
   // Used for inputs relevant to the domain, but not part of the domain string.
   // Example: { "authorization": <signature> } for an account-restricted domain.
-  domainOptions?: DomainOptions
+  options?: EIP712Object
   // Query message. A blinded elliptic curve point encoded in base64.
   blindedMessage: string
   // Client-specified session ID.
@@ -141,11 +151,11 @@ interface Domain {
   [key: string]: EIP712Value
 }
 
-interface DomainOptions {
-  // Arbitrary key-value pairs.
-  // Valid keys and values depend on the domain specification.
-  // SHOULD be serializeable to EIP-712 encoding.
-  [key: string]: EIP712Value
+interface DomainRestrictedSignatureResponse {
+  success: boolean
+  version: string
+  error?: string
+  signature?: string
 }
 ```
 
@@ -188,7 +198,11 @@ In addition to the domain string, a ruleset MAY allow a number of "domain option
 are defined by and are relevant to a particular ruleset, but are not part of the domain (i.e. their
 value does not effect the function output).
 
-### Examples
+Note that domain options, unlike domains themselves, are considered "subjective" in that a client
+may submit a different valid set of domain options (e.g. a different signature) to each ODIS signer
+without effecting their ability to reconstruct the complete secret.
+
+#### Examples
 
 The following examples are provided to help understand the scheme. They will likely not be
 implemented as described.
@@ -303,6 +317,104 @@ type SmartContractDomainOptions = {
 }
 ```
 
+### Optional domain endpoints
+
+All valid domains MUST implement the signature request. Additionally, a given domain MAY support
+additional functionality through optional API endpoints. In particular, two are defined below to
+check the available quota for a given domain, and to disable a domain.
+
+#### Quota status
+
+In many applications, it is useful for a client to have detailed information about what quota is
+available. For example, if the domain is used for a password-derived encryption key, it is important
+to rotate to a new domain instance if quota is running low on the existing one. If quota is entirely
+used on that domain instance, the derived secret may become unrecoverable.
+
+Each domain type has its own quota accounting rules and state, therefore there is no way to
+construct a generic representation of available quota on all domains. It is expected that most
+domains will maintain some amount of state (i.e. number of queries made against a domain) in a local
+database for the purpose of quota accounting. Domain quota state SHOULD be made available to the
+client through the following API unless privacy concerns prevent making this information available.
+(E.g. If a domain imposes an IP address based quota, this API should not return the complete list of
+all IP addresses that have queried the API to the user). In the response, the status field SHOULD
+contain the relevant state used by the service for rate limiting. This status information SHOULD
+include whether or not the domain is disabled, if the domain supports disabling.
+
+Similar to the signature request, the quota status request MAY include a number of domain-specific
+options. Note that the valid options for the quota status request MAY NOT be the same as the valid
+options for the signature request.
+
+Note that different ODIS signers may have distinct views on a domain's quota status. This can be the
+case if a request was not received by all signers. Clients SHOULD handle this possible discrepancy
+by checking their quota with all, or at least a quorum of signers, and taking their quota to be most
+restrictive result of any quorum.
+
+```typescript
+// POST /getDomainQuotaStatus
+// Headers:
+//   Content-Type: application/json
+interface DomainQuotaStatusRequest {
+  // Domain specification.
+  domain: Domain
+  // Domain-specific options.
+  // Used for inputs relevant to the domain, but not part of the domain string.
+  // Example: { "authorization": <signature> } for an account-restricted domain.
+  options?: EIP712Object
+  // Client-specified session ID.
+  sessionID?: string
+}
+
+interface DomainQuotaStatusResponse {
+  success: boolean
+  version: string
+  error?: string
+  status?: object
+}
+```
+
+#### Disable domain
+
+In some applications it is useful for clients to have an option to disable a domain such that no
+further requests can be made against this domain. For example, if the domain is used for a
+password-derived encryption key, the old domain instance should be disabled upon key rotation such
+that an attacker who gains access to the old ciphertext cannot use the old domain to make guesses on
+the user's password.
+
+Similar to the signature request, the disable domain request MAY include a number of domain-specific
+options. Note that the valid options for the disable domain request MAY NOT be the same as the valid
+options for the signature request.
+
+Upon receiving a valid request to disable a supported domain, the service MUST mark the domain as
+disabled in its database. Disabling a domain SHOULD be permanent. The service MAY delete any other
+state information for a permanently disabled domain. Any signature requests received for a disabled
+domain MUST result in a error response.
+
+```typescript
+// POST /disableDomain
+// Headers:
+//   Content-Type: application/json
+interface DisableDomainRequest {
+  // Domain specification.
+  // Selects the PRF domain and rate limiting rules.
+  domain: Domain
+  // Domain-specific options.
+  // Used for inputs relevant to the domain, but not part of the domain string.
+  // Example: { "authorization": <signature> } for an account-restricted domain.
+  options?: EIP712Object
+  // Query message. A blinded elliptic curve point encoded in base64.
+  blindedMessage: string
+  // Client-specified session ID.
+  sessionID?: string
+}
+
+interface DisableDomainResponse {
+  success: boolean
+  version: string
+  error?: string
+  status?: object
+}
+```
+
 ### Domain serialization
 
 Because any variation in the domain string, by design, results in an unpredictable change in the
@@ -363,7 +475,7 @@ domainSeparator = keccak256(
   keccak256("ODIS Linear Backoff Domain") || keccak256("1")
 )
 typeHash = keccak256(
-  "LinearBackoffDomain(int256 cap, Optional<int256> refresh, Optional<string> salt)" ||
+  "LinearBackoffDomain(int256 cap,Optional<int256> refresh,Optional<string> salt)" ||
   "Optional<int256>(bool defined,int256 value)" ||
   "Optional<string>(bool defined,string value)"
 )
@@ -386,8 +498,6 @@ encoded = 0x1901 || domainSeparator || structHash
 
 ### Signatures
 
-<!-- DO NOT MERGE Add info about signatures over quota check and burn requests -->
-
 Signatures are a useful primitive for authenticated rate limiting (e.g. allowing a higher rate limit
 to the owners of verified accounts on Celo). In order to facilitate this, the entire request struct
 SHOULD be deterministically hashed, specifically using EIP-712.
@@ -398,21 +508,30 @@ be included, such as an expiration time or nonce.
 
 Signatures SHOULD be verified over the entire request, excluding the signature itself. Specifically,
 the message against which a signature is verified SHOULD be obtained by first setting the signature
-field value to its zero value (e.g. empty string), then hashing the `GetDomainRestrictedSigRequest`
+field value to its zero value (e.g. empty string), then hashing the `DomainRestrictedSignatureRequest`
 object via EIP-712.
 
-Serializing the request SHOULD use the EIP-712 domain `{ name: "ODIS Domain Restricted Signature
-Request", version: "1" }` and type defined by applying the type mapping [defined
-above](#mapping-typescript-to-eip-712-types) to the `GetDomainRestrictedSigRequest` type.
+Serializing an API request SHOULD the type mapping defined above and the following EIP-712 domains:
+
+* `DomainRestrictedSignatureRequest` -> `{ name: "ODIS Domain Restricted Signature Request", version: "1" }`
+* `DomainQuotaStatusRequest` -> `{ name: "ODIS Domain Quota Status", version: "1" }`
+* `DisableDomainRequest` -> `{ name: "ODIS Disable Domain Request", version: "1" }`
 
 ### HTTP Transport
 
 When requested over HTTP, which is the primary proposed transport, the following HTTP semantics
 SHOULD be followed.
 
+Response bodies SHOULD be JSON encoded, including in the success and error cases. In error cases,
+an error message SHOULD be included in the response.
+
+<!-- TODO(victor): After some more thought, its unclear if using these response codes is the best.
+Consider having all responses use a common HTTP code with the error noted in the response body
+instead -->
+
 If a given `name` and `version` are not recognized by an ODIS signer, it SHOULD return a `404: Not
 Found` error. If a given `name` and `version` are recognized, but are deprecated, it SHOULD
-return a `405: Method Not Allowed` error. Signers SHOULD keep a list of all old domain names and
+return a `410: Gone` error. Signers SHOULD keep a list of all old domain names and
 version, even if they are no longer supported.
 
 When a user's request is rejected for violating the rate limiting of a domain, the service SHOULD
@@ -421,6 +540,10 @@ the same domain, the service SHOULD include the `Retry-After` header to specify 
 must wait. ODIS servers MAY apply additional rate limiting, such as by IP address. Any rate limiting
 rules outside of those applied per domain MUST be counted against first, such that a request
 dropped by optional rate limiting rules will not be counted against the domain quota.
+
+Requests which fail authentication, such as when a domain requires a signature but none is provided,
+SHOULD receive a `401: Unauthorized` response status. Requests for signatures on a disabled domain
+SHOULD receive a `403: Forbidden` response status.
 
 ### Key management
 

--- a/CIPs/cip-0040.md
+++ b/CIPs/cip-0040.md
@@ -20,7 +20,8 @@ described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119.html).
 ## Simple Summary
 
 An extension to the ODIS phone number privacy service to support granular rate limiting with the
-goal of hardening passwords for use as encryption and authorization keys.
+goal of hardening passwords for use as encryption and authorization keys, as well as other future
+use cases.
 
 ## Abstract
 
@@ -33,14 +34,14 @@ blinded input (e.g.  phone number or password).
 Central to the proposed interface are domains. A domain is a struct which specifies rate limiting
 information and uniquely identifies the context of the secret to be hashed. As an example, a domain
 for hashing an account password might specify an application username of "vitalik.eth" (context) and
-a cap of 10 password attempts (rate-limiting parameter). These would be combined with their password
-in a one-way function to form the final output.
+a cap of 10 password attempts (rate-limiting parameter). These would be combined with the user's
+password (blinded input) in a one-way function to form the final output.
 
 Queries with distinct domain specifiers will receive uncorrelated output. For example, output from
-ODIS with the phone number domain and message `+18002738255` will be distinct from and
-unrelated to the output when requesting with a password domain and message `+18002738255`.
+ODIS with the phone number domain and message `18002738255` will be distinct from and
+unrelated to the output when requesting with a password domain and message `18002738255`.
 
-Additionally, domain specifiers will control what rate limiting rules are applied. For example the
+Additionally, domain specifiers will control what rate limiting rules are applied. For example, the
 phone number domain could use the current ODIS rate limiting rules, while the password domain may
 use much stricter rules, with parameters that can be tuned by the user or application developer.
 Combined with the fact that distinct domains produce uncorrelated output, this allows for the
@@ -48,7 +49,8 @@ domains to be used as distinct OPRFs with tunable rate limiting rules.
 
 In order to make this scheme flexible, allowing for user-defined tuning of rate-limits and the
 introduction of new rate limiting and authorization rules in the future, domains are defined as
-serializeable structs.
+serializeable structs. New domain types, with associated rate-limiting rules, may be added in the
+future to meet the needs of new applications.
 
 ## Motivation
 
@@ -57,9 +59,9 @@ limit the use of passwords to derive encryption or authentication keys. Rate-lim
 used to make it much more difficult to crack a password. Computationally expensive password hashing
 functions, such as `PBKDF` and `scrypt`, are commonly used for this purpose, but provide [limited
 protection](https://arxiv.org/abs/2006.05023) and are expensive to run on end-user devices. ODIS,
-the phone number privacy service on Celo, implements a rate-limited hash to protect users' phone
+the phone number privacy service on Celo, implements rate-limited hashing to protect users' phone
 numbers from being extracted from their on-chain identifiers. With some extensions, ODIS can
-additionally be used to provide a rate-limited hash for passwords, as well as many more use cases.
+additionally be used to provide rate-limited hashing for passwords, as well as many more use cases.
 
 [Phone Number Privacy](https://docs.celo.org/celo-codebase/protocol/identity/phone-number-privacy)
 
@@ -78,11 +80,9 @@ that is visible to the service.
 ## Specification
 
 In order to support granular rate-limited hash functionality, ODIS will need to support a new
-interface which accepts a domain specifiers, visible to the service, alongside the blinded input.
+interface which accepts a domain specifier, visible to the service, alongside the blinded input.
 
 ### Service APIs
-
-[celo-org/celo-monorepo](https://github.com/celo-org/celo-monorepo/tree/master/packages/phone-number-privacy/signer)
 
 #### Existing blinded requests
 
@@ -119,6 +119,8 @@ interface SignMessageResponse {
 }
 ```
 
+[celo-org/celo-monorepo](https://github.com/celo-org/celo-monorepo/tree/master/packages/phone-number-privacy/signer)
+
 #### Extension for domain-restricted requests
 
 In order to support domain-restricted queries, a new API is proposed:
@@ -144,8 +146,8 @@ interface DomainRestrictedSignatureRequest {
 interface Domain {
   // Unique name of the domain. (e.g. "ODIS Password Domain")
   name: string
-  // Major version number. Allows for backwards incompatible changes.
-  version: number
+  // Version number. Allows for backwards incompatible changes.
+  version: string
   // Arbitrary key-value pairs.
   // MUST be serializeable to EIP-712 encoding.
   [key: string]: EIP712Value
@@ -167,8 +169,7 @@ Domain specifiers serve two functions:
 - Specify the rate limiting function to be used in deciding whether to serve the request.
 
 In order to provide flexibility and support future extensions, the domain specifier is structured
-and allows for the usage of multiple domain-specific rate limiting rules, as support by the ODIS
-service.
+and may be one of a number of implemented types.
 
 In the domain specifiers, two fields MUST be provided: `name` and `version`. Together, these select
 which set of rules the service will apply to the request. Rule sets are included in the ODIS
@@ -181,20 +182,20 @@ accompanied by an increase in the `version` number. Domain names SHOULD be human
 numbers SHOULD be whole integers.
 
 A domain `name` and `version` MAY be deprecated such that the service will return an error for new
-requests. Deprecation of a domain will make all secrets hashed under that domain inaccessible.
-Depending on the application, it is likely to be very difficult to full deprecate a domain, as users
-will need to actively migrate any usages from the deprecated domain.
+requests. Deprecation of a domain will make all secrets derived under that domain inaccessible.
+Depending on the application, it is likely to be very difficult to fully deprecate a domain, as
+users will need to actively migrate any usages from the deprecated domain.
 
 With a given `name` and `version`, a number of additional fields MAY be specified to act as
-parameters for the rate limiting ruleset (e.g. in a linear backoff ruleset, a field may define the
-refresh rate) and to establish the context. In order to ensure deterministic serialization, each
-`name` and `version` MUST correspond to a single type definition.
+parameters for the rate limiting ruleset and to establish the context. In order to ensure
+deterministic serialization, each `name` and `version` MUST correspond to a single type definition.
+Note that adding a field to an existing domain is a backwards incompatible change.
 
 Changing any field in the domain specifier, results in a new domain with completely unrelated
 output. (e.g. an attacker cannot simply dial down the security level of a domain. If they tried,
 they would get useless output.)
 
-In addition to the domain string, a ruleset MAY allow a number of "domain options". Domain options
+In addition to the domain string, a ruleset MAY accept a number of "domain options". Domain options
 are defined by and are relevant to a particular ruleset, but are not part of the domain (i.e. their
 value does not effect the function output).
 
@@ -204,8 +205,8 @@ without effecting their ability to reconstruct the complete secret.
 
 #### Examples
 
-The following examples are provided to help understand the scheme. They will likely not be
-implemented as described.
+The following examples are provided to help understand the scheme. They are for illustrative
+purposes only and will likely not be implemented as described here.
 
 **Linear backoff:** A rate limiting scheme allowing up to a given number of requests in a defined
 time period could be implemented as a linear backoff with some amount of saved-up quota cap.
@@ -213,7 +214,7 @@ time period could be implemented as a linear backoff with some amount of saved-u
 ```typescript
 type LinearBackoffDomain = {
   name: "ODIS Linear Backoff Domain"
-  version: 1
+  version: "1"
   // Length of time, in milliseconds, to refresh a single unit of quota.
   // Undefined refresh time indicates that the quota never refreshes (hard cap).
   refresh?: number
@@ -225,12 +226,13 @@ type LinearBackoffDomain = {
 ```
 
 **Not before:** Useful in the lotteries and other random-selection based protocols, a domain could
-be created to restrict requests before a particular time, but publicly available after.
+be created to restrict requests before a particular time, but makes the output publicly available
+after.
 
 ```typescript
 type NotBeforeDomain = {
   name: "ODIS Not Before Domain"
-  version: 1
+  version: "1"
   // Unix time after which this domain can be queried.
   notBefore: number
 }
@@ -243,7 +245,7 @@ stored alongside the ciphertext.
 ```typescript
 type PepperedDomain = {
   name: "ODIS Peppered Domain"
-  version: 1
+  version: "1"
   // Public key of a key-pair derived from the pepper.
   publicKey: string
   // Maximum number of requests that can be made against this domain.
@@ -262,7 +264,7 @@ domain in the new API. A domain string and options could be written as follows:
 ```typescript
 type PhoneNumberDomain = {
   name: "ODIS Phone Number Domain"
-  version: 1
+  version: "1"
 }
 
 type PhoneNumberDomainOptions = {
@@ -293,7 +295,7 @@ value from the contract function.
 ```typescript
 type SmartContractDomain = {
   name: "ODIS Smart Contract Domain"
-  version: 1
+  version: "1"
   // Address of the contract that controls access to this domain.
   // Call will occur as a view call at the chain head upon receiving
   // the request to determine rate limiting.
@@ -332,13 +334,15 @@ used on that domain instance, the derived secret may become unrecoverable.
 
 Each domain type has its own quota accounting rules and state, therefore there is no way to
 construct a generic representation of available quota on all domains. It is expected that most
-domains will maintain some amount of state (i.e. number of queries made against a domain) in a local
+domains will maintain some amount of state (i.e. number of queries made against a domain) in a
 database for the purpose of quota accounting. Domain quota state SHOULD be made available to the
 client through the following API unless privacy concerns prevent making this information available.
 (E.g. If a domain imposes an IP address based quota, this API should not return the complete list of
-all IP addresses that have queried the API to the user). In the response, the status field SHOULD
-contain the relevant state used by the service for rate limiting. This status information SHOULD
-include whether or not the domain is disabled, if the domain supports disabling.
+all IP addresses that have queried the API to the user).
+
+In the response, the status field SHOULD contain the relevant state used by the service for rate
+limiting. This status information SHOULD include whether or not the domain is disabled, if the
+domain supports disabling.
 
 Similar to the signature request, the quota status request MAY include a number of domain-specific
 options. Note that the valid options for the quota status request MAY NOT be the same as the valid
@@ -347,7 +351,7 @@ options for the signature request.
 Note that different ODIS signers may have distinct views on a domain's quota status. This can be the
 case if a request was not received by all signers. Clients SHOULD handle this possible discrepancy
 by checking their quota with all, or at least a quorum of signers, and taking their quota to be most
-restrictive result of any quorum.
+restrictive result of the least restrictive quorum.
 
 ```typescript
 // POST /getDomainQuotaStatus
@@ -357,8 +361,6 @@ interface DomainQuotaStatusRequest {
   // Domain specification.
   domain: Domain
   // Domain-specific options.
-  // Used for inputs relevant to the domain, but not part of the domain string.
-  // Example: { "authorization": <signature> } for an account-restricted domain.
   options?: EIP712Object
   // Client-specified session ID.
   sessionID?: string
@@ -375,10 +377,10 @@ interface DomainQuotaStatusResponse {
 #### Disable domain
 
 In some applications it is useful for clients to have an option to disable a domain such that no
-further requests can be made against this domain. For example, if the domain is used for a
-password-derived encryption key, the old domain instance should be disabled upon key rotation such
-that an attacker who gains access to the old ciphertext cannot use the old domain to make guesses on
-the user's password.
+further signature requests will be accepted. For example, if the domain is used for a
+password-derived encryption key, the old domain instance should be disabled upon domain instance
+rotation such that an attacker who gains access to the old ciphertext cannot use the old domain to
+make guesses on the user's password.
 
 Similar to the signature request, the disable domain request MAY include a number of domain-specific
 options. Note that the valid options for the disable domain request MAY NOT be the same as the valid
@@ -396,11 +398,8 @@ quota checks such that the error response indicates the domain is disabled.
 //   Content-Type: application/json
 interface DisableDomainRequest {
   // Domain specification.
-  // Selects the PRF domain and rate limiting rules.
   domain: Domain
   // Domain-specific options.
-  // Used for inputs relevant to the domain, but not part of the domain string.
-  // Example: { "authorization": <signature> } for an account-restricted domain.
   options?: EIP712Object
   // Query message. A blinded elliptic curve point encoded in base64.
   blindedMessage: string
@@ -463,7 +462,7 @@ As an example, the following instance of a `LinearBackoffDomain` is hashed:
 ```typescript
 const domain: LinearBackoffDomain = {
   name: "ODIS Linear Backoff Domain"
-  version: 1
+  version: "1"
   cap: 10
   salt: "saltvalue"
 }

--- a/CIPs/cip-0040.md
+++ b/CIPs/cip-0040.md
@@ -237,9 +237,7 @@ type PepperedDomain = {
 }
 
 type PepperedDomainOptions = {
-  // Nonce value to include in the signature message to make it unique.
-  nonce: number
-  // EIP-712 signature over the request.
+  // EIP-712 signature over the entire request.
   signature: string
 }
 ```
@@ -388,18 +386,20 @@ encoded = 0x1901 || domainSeparator || structHash
 
 ### Signatures
 
+<!-- DO NOT MERGE Add info about signatures over quota check and burn requests -->
+
 Signatures are a useful primitive for authenticated rate limiting (e.g. allowing a higher rate limit
 to the owners of verified accounts on Celo). In order to facilitate this, the entire request struct
-SHOULD be deterministically serializeable, specifically using EIP-712.
+SHOULD be deterministically hashed, specifically using EIP-712.
 
 Domains that make use of signatures for authentication of requests (e.g. the `PepperedDomain`
-example below) SHOULD include a field in the domain options for specification of a signature.
-Additional fields MAY also be added, such as a nonce to prevent replaying requests.
+example above) SHOULD include the signature field in the domain options. Additional fields MAY also
+be included, such as an expiration time or nonce.
 
 Signatures SHOULD be verified over the entire request, excluding the signature itself. Specifically,
 the message against which a signature is verified SHOULD be obtained by first setting the signature
-field value to its zero value (e.g. empty string) object, then serializing the
-`GetDomainRestrictedSigRequest` object via EIP-712.
+field value to its zero value (e.g. empty string), then hashing the `GetDomainRestrictedSigRequest`
+object via EIP-712.
 
 Serializing the request SHOULD use the EIP-712 domain `{ name: "ODIS Domain Restricted Signature
 Request", version: "1" }` and type defined by applying the type mapping [defined
@@ -410,8 +410,8 @@ above](#mapping-typescript-to-eip-712-types) to the `GetDomainRestrictedSigReque
 When requested over HTTP, which is the primary proposed transport, the following HTTP semantics
 SHOULD be followed.
 
-If a given `name` and `version` are not recognized by an ODIS signer, it SHOULD return a `501: Not
-Implemented` error. If a given `name` and `version` are recognized, but are deprecated, it SHOULD
+If a given `name` and `version` are not recognized by an ODIS signer, it SHOULD return a `404: Not
+Found` error. If a given `name` and `version` are recognized, but are deprecated, it SHOULD
 return a `405: Method Not Allowed` error. Signers SHOULD keep a list of all old domain names and
 version, even if they are no longer supported.
 

--- a/CIPs/cip-0040.md
+++ b/CIPs/cip-0040.md
@@ -387,7 +387,8 @@ options for the signature request.
 Upon receiving a valid request to disable a supported domain, the service MUST mark the domain as
 disabled in its database. Disabling a domain SHOULD be permanent. The service MAY delete any other
 state information for a permanently disabled domain. Any signature requests received for a disabled
-domain MUST result in a error response.
+domain MUST result in a error response. Checking whether a domain is disabled SHOULD occur before
+quota checks such that the error response indicates the domain is disabled.
 
 ```typescript
 // POST /disableDomain
@@ -529,10 +530,11 @@ an error message SHOULD be included in the response.
 Consider having all responses use a common HTTP code with the error noted in the response body
 instead -->
 
-If a given `name` and `version` are not recognized by an ODIS signer, it SHOULD return a `404: Not
-Found` error. If a given `name` and `version` are recognized, but are deprecated, it SHOULD
-return a `410: Gone` error. Signers SHOULD keep a list of all old domain names and
-version, even if they are no longer supported.
+If a given `name` and `version` are not recognized by an ODIS signer, or the request is to an
+optional endpoint not supported by the given domain, the service SHOULD return a `404: Not Found`
+error. If a given `name` and `version` are recognized, but are deprecated, it SHOULD return a `410:
+Gone` error. Signers SHOULD keep a list of all old domain names and version, even if they are no
+longer supported.
 
 When a user's request is rejected for violating the rate limiting of a domain, the service SHOULD
 respond with `429: Too Many Requests`. If the waiting would allow for additional requests against


### PR DESCRIPTION
In order to address concerns in designing a Celo account cloiud backup scheme, which utilizes this
new API, I've added two optional APIs to the proposal, which would be implemented for a
password-hashing domain.

* `getDomainQuotaStatus` would return to the information to the client so the can know a domain's quota.
* `disableDomain` would alow a client to permanantly disable a domain, which is useful for security.

Additionally, I made a number of smaller changes while reading through the proposal. One area I
realised was poorly specified before was the HTTP semantics. It's still unclear to me what the best
HTTP semantics are for this application, especially given the user of the combiner as a non-standard
proxy and a desire to be forwards compatible with other transports (e.g. WebSockets or gRPC).