### PR TITLE
Fix numbers b/c markdown has an octal syntax 

### DIFF
--- a/CIPs/cip-0041.md
+++ b/CIPs/cip-0041.md
@@ -1,5 +1,5 @@
 ---
-cip: 0041
+cip: 41
 title: E Hardfork
 author: Joshua Gutow <@trianglesphere>
 discussions-to: https://github.com/celo-org/celo-proposals/issues/261

--- a/CIPs/cip-0042.md
+++ b/CIPs/cip-0042.md
@@ -1,5 +1,5 @@
 ---
-cip: 0042
+cip: 42
 title: Modification to EIP-1559
 author: Joshua Gutow <@trianglesphere>
 discussions-to: https://github.com/celo-org/celo-proposals/issues/262


### PR DESCRIPTION
41 base 8 is 33 base 10. The two zeroes (like `0041`) resulted in the number being interpreted as octal.