### PR TITLE
Remove EIP-3554 from the Espresso Hardfork

### DIFF
--- a/CIPs/cip-0041.md
+++ b/CIPs/cip-0041.md
@@ -46,15 +46,14 @@ From Berlin
 
 From London
 * [EIP-1559: Fee market change for ETH 1.0 chain](https://eips.ethereum.org/EIPS/eip-1559)
-* [EIP-3198: BASEFEE opcode](https://eips.ethereum.org/EIPS/eip-3198)
 * [EIP-3529: Reduction in refunds](https://eips.ethereum.org/EIPS/eip-3529)
 * [EIP-3541: Reject new contracts starting with the 0xEF byte](https://eips.ethereum.org/EIPS/eip-3541)
 
 Modifications to the EIPs
 * [EIP-3554: Difficulty Bomb Delay](https://eips.ethereum.org/EIPS/eip-3554) (Included in London) will not be included in the "E" Hardfork
+* [EIP-3198: BASEFEE opcode](https://eips.ethereum.org/EIPS/eip-3198) (Included in London) will not be included in the "E" Hardork. It creates a circular dependency in the EVM and is not well formed on Celo. See [this comment](https://github.com/celo-org/celo-proposals/issues/261#issuecomment-958095771) for more information.
 * [CIP-42](https://github.com/celo-org/celo-proposals/blob/master/CIPs/cip-0042.md): Modifies EIP-1559 as it is already partially implemented on Celo but the upstream implementation does not match what is on Celo.
 * [CIP-48](https://github.com/celo-org/celo-proposals/blob/master/CIPs/cip-0048.md): Modifies EIP-2929. Celo has not adopted EIP-1884 gas price changes, thus this brings the rough costs from EIP-1884 to EIP-2929.
-* The `BASEFEE` opcode should return the result of calling `getGasPriceMinimum` to the `GasPriceMinimum` smart contract at the end of the previous block.
 
 CIPs to be Included
 * [CIP-43](https://github.com/celo-org/celo-proposals/blob/master/CIPs/cip-0043.md): Block Context


### PR DESCRIPTION
EIP-3198 added the BaseFee opcode to the ethereum virtual machine. Initially that was to be included in the espresso hardfork for the Celo network, but there is not a well formed way to implement the opcode with how the GasPriceMinimum mechanism is implemented.

In particular, the gas price minimum (equivalent to the BaseFee), is updated in the GasPriceMinimum smart contract. The gas price minimum is also stored in the contract and can be accessed. The value returned by OpBaseFee can only be determined by calling into the GasPriceMinimum contract. If the OpBaseFee opcode were to exist, the GasPriceMinimum would not be able to use that opcode as it is self-referential. It is possible to limit the contract to using a subset of the EVM, but that option is tricky and adds a lot of complexity.

Instead of OpBaseFee, smart contract developers can use getGasPriceMinimum in the GasPriceminimum smart contract.