### PR TITLE
CIP-20: fix syntax

### DIFF
--- a/CIPs/cip-0020.md
+++ b/CIPs/cip-0020.md
@@ -2,7 +2,7 @@
 cip: 20
 title: Generic hash function support via extensible precompile
 author: James Prestwich <james@prestwi.ch>
-discussions-to: [link](https://github.com/celo-org/celo-proposals/issues/99)
+discussions-to: https://github.com/celo-org/celo-proposals/issues/99
 status: Accepted
 type: Standards
 category: Ring 0


### PR DESCRIPTION
The markdown syntax in the `discussions-to` field of the front matter breaks github's rendering with the error
```
Error in user YAML: (<unknown>): did not find expected key while parsing a block mapping at line 1 column 1
```

It should just contain the plain URL.