### PR TITLE
Change CIP-52 error handling case

### DIFF
--- a/CIPs/cip-0052.md
+++ b/CIPs/cip-0052.md
@@ -40,7 +40,7 @@ The proposal can change the Carbon Offset Fund via a Governance Proposal by exec
 
 Currently 100% of the base fee is sent to the Governance Proxy address (also known as on-chain Community Fund) for all the tokens supported as fee currency. 
 
-In a hard-fork, this needs to be changed for the address of a new Core Contract called `FeeHander` (with the same key in the registry contract). In case this contract for some reason is not in the registry, the blockchain client should issue a warning and send the tokens to the Governance Proxy instead.
+In a hard-fork, this needs to be changed for the address of a new Core Contract called `FeeHander` (with the same key in the registry contract). In case this contract for some reason is not in the registry, the blockchain client should issue a warning and refund the base fee to the sender.
 
 ### For Celo
 


### PR DESCRIPTION
The original CIP requires handling three cases:
1. FeeHandler registered
2. FeeHandler not registered but Governance is
3. neither is registered

Having less cases makes the code cleaner, reduces the chances of having an error handling that does not actually work and creates less unusual situations that are hard to understand for people watching the blockchain.

Therefore I suggest removing case 2 and use the same error handler as in case 3: refunding to the sender.