### PR TITLE
Fix link destination

### DIFF
--- a/CIPs/cip-0066.md
+++ b/CIPs/cip-0066.md
@@ -21,7 +21,7 @@ This new transaction is encoded as follows: `0x7a || rlp([chainId, nonce, maxPri
 
 Compared to EIP-1559, the fields `feeCurrency` and `maxFeeInFeeCurrency` are added.
 
-Compared to [CIP-64](https://github.com/Conflux-Chain/CIPs/blob/master/CIPs/cip-64.md), the field `maxFeeInFeeCurrency` is added, and the unit for the fields `maxPriorityFeePerGas`, `maxFeePerGas` is changed from the fee currency to the native CELO token.
+Compared to [CIP-64](https://github.com/celo-org/celo-proposals/blob/master/CIPs/cip-0064.md), the field `maxFeeInFeeCurrency` is added, and the unit for the fields `maxPriorityFeePerGas`, `maxFeePerGas` is changed from the fee currency to the native CELO token.
 
 ## Motivation
 


### PR DESCRIPTION
The CIP-64 link pointed to the wrong blockchain's improvement proposal 🙃