### PR TITLE
Mark CIPs superseded/removed by CIP-63

### DIFF
--- a/CIPs/cip-0020.md
+++ b/CIPs/cip-0020.md
@@ -3,12 +3,15 @@ cip: 20
 title: Generic hash function support via extensible precompile
 author: James Prestwich <james@prestwi.ch>
 discussions-to: https://github.com/celo-org/celo-proposals/issues/99
-status: Final
+status: Superseded
 type: Standards
 category: Ring 0
 created: 2020-10-25
 license: Apache 2.0
 ---
+
+> [!IMPORTANT]  
+> This feature has been removed in [CIP-63](https://github.com/celo-org/celo-proposals/blob/master/CIPs/cip-0063.md).
 
 ### Terminology
 

--- a/CIPs/cip-0025.md
+++ b/CIPs/cip-0025.md
@@ -3,12 +3,15 @@ cip: 25
 title: Ed25519 precompile
 author: Joe Bowman <joe@chorus.one>
 discussions-to: https://github.com/celo-org/celo-proposals/issues/91
-status: Final
+status: Superseded
 type: Standards
 category: Ring 0
 created: 2020-11-18
 license: Apache 2.0
 ---
+
+> [!IMPORTANT]  
+> This feature has been removed in [CIP-63](https://github.com/celo-org/celo-proposals/blob/master/CIPs/cip-0063.md).
 
 ### Terminology
 

--- a/CIPs/cip-0030.md
+++ b/CIPs/cip-0030.md
@@ -3,11 +3,14 @@ cip: 30
 title: Precompile for BLS12-377 curve operations
 author: James Prestwich <prestwich@clabs.co>, original by Alex Vlasov (@shamatar)
 discussions-to: https://github.com/celo-org/celo-proposals/issues/112
-status: Final
+status: Superseded
 type: Standards Track
 category: Ring 0
 created: 2020-12-08
 ---
+
+> [!IMPORTANT]  
+> This feature has been removed in [CIP-63](https://github.com/celo-org/celo-proposals/blob/master/CIPs/cip-0063.md).
 
 ## Simple Summary
 This precompile adds operation on BLS12-377 curve (from Zexe paper) as a precompile in a set necessary to *efficiently* perform operations such as BLS signature verification and perform SNARKs verifications. Unique properties of BLS12-377 also later allow to have SNARKs that check BLS12-377 pairing in an efficient way and allow e.g. constant-size BLS signature aggregation.

--- a/CIPs/cip-0031.md
+++ b/CIPs/cip-0031.md
@@ -3,11 +3,14 @@ cip: 31
 title: Precompile for BLS12-381 curve operations
 author: James Prestwich <prestwich@clabs.co>, original by Alex Vlasov (@shamatar)
 discussions-to: https://github.com/celo-org/celo-proposals/issues/113
-status: Final
+status: Superseded
 type: Standards Track
 category: Ring 0
 created: 2020-12-08
 ---
+
+> [!IMPORTANT]  
+> This feature has been removed in [CIP-63](https://github.com/celo-org/celo-proposals/blob/master/CIPs/cip-0063.md).
 
 ## Simple Summary
 


### PR DESCRIPTION
We don't want people reading the old CIPs without realizing that support for them has ended.

I expect the syntax to render as shown in https://github.com/orgs/community/discussions/16925.